### PR TITLE
Give the params of the mod function distinct names

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -4,8 +4,8 @@
  * @param number
  * @param mod
  */
-module.exports.mod = function mod(number, mod) {
-  return ((number % mod) + mod) % mod;
+module.exports.mod = function mod(number, modulus) {
+  return ((number % modulus) + modulus) % modulus;
 }
 
 /**


### PR DESCRIPTION
Because a param named `mod` of a function named `mod` is not only gross, but violates strict mode.