### PR TITLE
Update repo configuration to allow for better npm packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ Icon?
 /.cake_task_cache
 
 # Build files
-/build/*
+/lib
 
 # VScode settings
 /.vscode

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "@code-dot-org/maze",
   "version": "1.0.0",
   "description": "standalone project for the Maze app type",
-  "main": "build/bundle.js",
+  "files": [
+    "lib/maze.js"
+  ],
+  "main": "lib/maze.js",
   "scripts": {
-    "build": "webpack --progress --colors",
+    "build": "webpack -p",
+    "build:dev": "webpack --progress --colors",
     "lint": "eslint --ext .js src/ test",
     "test": "npm run lint && npm run test:unit",
     "test:unit": "jest",

--- a/src/cells.js
+++ b/src/cells.js
@@ -1,0 +1,14 @@
+/**
+ * @overview single point of entry for requiring all Cell subclasses
+ */
+const Cell = require('./cell');
+const BeeCell = require('./beeCell');
+const HarvesterCell = require('./harvesterCell');
+const PlanterCell = require('./planterCell');
+
+module.exports = {
+  Cell,
+  BeeCell,
+  HarvesterCell,
+  PlanterCell,
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,17 @@
+const MazeController = require('./mazeController');
+const cells = require('./cells');
+const drawMap = require('./drawMap');
+const mazeMap = require('./mazeMap');
+const subtypes = require('./subtypes');
+const tiles = require('./tiles');
+const utils = require('./utils');
+
+module.exports = {
+  MazeController,
+  cells,
+  drawMap,
+  mazeMap,
+  subtypes,
+  tiles,
+  utils,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,16 @@
 const MazeController = require('./mazeController');
+const MazeMap = require('./mazeMap');
 const cells = require('./cells');
 const drawMap = require('./drawMap');
-const mazeMap = require('./mazeMap');
 const subtypes = require('./subtypes');
 const tiles = require('./tiles');
 const utils = require('./utils');
 
 module.exports = {
   MazeController,
+  MazeMap,
   cells,
   drawMap,
-  mazeMap,
   subtypes,
   tiles,
   utils,

--- a/src/subtypes.js
+++ b/src/subtypes.js
@@ -1,0 +1,19 @@
+/**
+ * @overview single point of entry for requiring all Subtype subclasses
+ */
+const Farmer = require('./farmer');
+const Bee = require('./bee');
+const Collector = require('./collector');
+const Wordsearch = require('./wordsearch');
+const Harvester = require('./harvester');
+const Planter = require('./planter');
+
+module.exports = {
+  Farmer,
+  Bee,
+  Collector,
+  Wordsearch,
+  Harvester,
+  Planter,
+}
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,26 +1,24 @@
 const path = require("path");
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const name = "maze";
 
 module.exports = {
-  entry: "./demo/playground.js",
+  entry: './src/index.js',
   output: {
-    path: path.resolve(__dirname, "build"),
-    filename: "bundle.js",
+    path: path.resolve(__dirname, "lib"),
+    filename: name + ".js",
+    library: name,
+    libraryTarget: 'umd',
+    umdNamedDefine: true
   },
+  target: 'node',
   module: {
     rules: [{
-      test: /\.jsx?$/,
+      test: /\.js$/,
       loader: "babel-loader",
-    }, {
-      test: /\.png$/,
-      loader: 'file-loader',
     }]
   },
-  plugins: [
-    new HtmlWebpackPlugin()
-  ],
   resolve: {
-    extensions: [".js", ".jsx"],
+    extensions: [".js"],
   },
   stats: {
     colors: true


### PR DESCRIPTION
Currently, we include this dependency by adding an npm dependency on the repo itself and requiring source files like this: (from [maze.js](https://github.com/code-dot-org/code-dot-org/blob/a70ed0386ab46172d77d049cc06c2fbea567e0dd/apps/src/maze/maze.js#L26-L27))

```javascript
const MazeController = require('@code-dot-org/maze/src/mazeController');
const tiles = require('@code-dot-org/maze/src/tiles');
```

I'd like us to instead add an npm package which we can include by version tag, and require the source like any other package:

```javascript
import { MazeController, tiles } from '@code-dot-org/maze';

or

const maze = require('@code-dot-org/maze');
const MazeController = maze.MazeController;
const tiles = maze.tiles;
```

To this end, I add a new `index.js` that includes all the points of entry we currently use in the codebase and update webpack and package.json to expose that as the only export.

Point of discussion: `MazeController` is in many senses the "primary" export of this package, so it would be nice to be able to instead include it like:

```javascript
import MazeController, { tiles } from '@code-dot-org/maze';

or

const MazeController = require('@code-dot-org/maze');
const tiles = MazeController.tiles;
```

But doing that would require either mangling the export object in `index.js` (which seems gross, but I'm not sure whether or not it's necessarily a wrong thing to do) or updating this repo to use ES6 exports rather than CommonJS (which has [its own issues](https://medium.com/the-node-js-collection/an-update-on-es6-modules-in-node-js-42c958b890c) that we [may or may not care about](https://github.com/code-dot-org/code-dot-org/pull/22076#issuecomment-384806674)). Thoughts?