### PR TITLE
Reenable demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Icon?
 
 # Build files
 /lib
+/demo/dist
 
 # VScode settings
 /.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ notifications:
 script:
   - yarn run test && codecov
 
-before_deploy: yarn build
+before_deploy: yarn run build:demo
 
 deploy:
-  local_dir: build
+  local_dir: demo/dist
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -1,0 +1,22 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin')
+const path = require("path");
+
+module.exports = {
+  entry: path.resolve(__dirname, 'playground.js'),
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: 'demo.js'
+  },
+  module: {
+    rules: [{
+      test: /\.js$/,
+      loader: "babel-loader",
+    }, {
+      test: /\.png$/,
+      loader: 'file-loader',
+    }]
+  },
+  plugins: [
+    new HtmlWebpackPlugin()
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "webpack -p",
     "build:dev": "webpack --progress --colors",
+    "build:demo": "webpack --config demo/webpack.config.js",
     "lint": "eslint --ext .js src/ test",
     "postversion": "git push && git push --tags && npm publish",
     "preversion": "npm run test",


### PR DESCRIPTION
https://github.com/code-dot-org/maze/pull/7 broke the demo build in favor of the npm build; this PR re-adds the demo build as a secondary concern