### PR TITLE
Ensure inner corners get a solid wall tile, not a randomized one

### DIFF
--- a/src/bee.js
+++ b/src/bee.js
@@ -398,7 +398,7 @@ module.exports = class Bee extends Gatherer {
   /**
    * @override
    */
-  getEmptyTile(x, y, adjacentToPath, wallMap) {
+  getEmptyTile(x, y, adjacentToPath) {
     // begin with three trees
     var tileChoices = ['null3', 'null4', 'null0'];
     var noTree = 'null1';

--- a/src/beeCell.js
+++ b/src/beeCell.js
@@ -1,5 +1,5 @@
 /**
- * @overview BeeCell represents the contets of the grid elements for Bee.
+ * @overview BeeCell represents the contents of the grid elements for Bee.
  * Bee BeeCells are more complex than many other kinds of cell; they can be
  * "hidden" with clouds, they can represent multiple different kinds of
  * element (flower, hive), some of which can be multiple colors (red,

--- a/src/subtype.js
+++ b/src/subtype.js
@@ -173,6 +173,7 @@ module.exports = class Subtype extends EventEmitter {
       // Draw the tile.
       if (!TILE_SHAPES[tile]) {
         const adjacentToPath = tile !== '00000';
+        // Any block with 2, 3 or 4 orthogonal paths.
         const innerCorner = adjacentToPath && tile.split('1').length > 2;
 
         // We have an empty square. Handle it differently based on skin.

--- a/src/subtype.js
+++ b/src/subtype.js
@@ -1,5 +1,5 @@
-const Cell = require('./cell')
-const DirtDrawer = require('./dirtDrawer')
+const Cell = require('./cell');
+const DirtDrawer = require('./dirtDrawer');
 
 const SquareType = require('./tiles').SquareType;
 const EventEmitter = require('events').EventEmitter; // provided by webpack's node-libs-browser
@@ -149,11 +149,6 @@ module.exports = class Subtype extends EventEmitter {
       tile = 'null' + wallIdx;
     }
 
-    // For the first 3 levels in maze, only show the null0 image.
-    if (['2_1', '2_2', '2_3'].includes(this.level_.id)) {
-      this.wallMap[y][x] = 0;
-      tile = 'null0';
-    }
     return tile;
   }
 

--- a/src/subtype.js
+++ b/src/subtype.js
@@ -30,6 +30,9 @@ const TILE_SHAPES = {
   'null4': [1, 3],
 };
 
+// Chance of showing a random wall tile other than the default.
+const RANDOM_TILE_RATE = 0.2;
+
 module.exports = class Subtype extends EventEmitter {
   constructor(maze, config) {
     super();
@@ -137,10 +140,10 @@ module.exports = class Subtype extends EventEmitter {
     );
   }
 
-  getEmptyTile(x, y, adjacentToPath) {
+  getEmptyTile(x, y, adjacentToPath, innerCorner) {
     let tile;
     // Empty square.  Use null0 for large areas, with null1-4 for borders.
-    if (!adjacentToPath && Math.random() > 0.3) {
+    if (innerCorner || (!adjacentToPath && Math.random() > RANDOM_TILE_RATE)) {
       this.wallMap[y][x] = 0;
       tile = 'null0';
     } else {
@@ -167,12 +170,13 @@ module.exports = class Subtype extends EventEmitter {
         this.isOnPathStr_(col, row + 1) + // South.
         this.isOnPathStr_(col - 1, row); // East.
 
-      const adjacentToPath = (tile !== '00000');
-
       // Draw the tile.
       if (!TILE_SHAPES[tile]) {
+        const adjacentToPath = tile !== '00000';
+        const innerCorner = adjacentToPath && tile.split('1').length > 2;
+
         // We have an empty square. Handle it differently based on skin.
-        tile = this.getEmptyTile(col, row, adjacentToPath);
+        tile = this.getEmptyTile(col, row, adjacentToPath, innerCorner);
       }
 
       this.drawTile(svg, TILE_SHAPES[tile], row, col, tileId);


### PR DESCRIPTION
Request from @kiki-lee.  For young students, having a triangle block at these locations can be confusing.

![image](https://user-images.githubusercontent.com/413693/42007133-1e11e2d8-7a33-11e8-8ee1-dcaa4e1dc9ab.png)

This also removes the special casing for puzzles 1, 2 & 4 of the original HoC.