### PR TITLE
Update jest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "jest": {
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "testURL": "http://localhost:8080"
   }
 }


### PR DESCRIPTION
In order to run tests locally, we need to add a `testUrl`to the jest config. This avoids a `localStorage is not available` error.