### PR TITLE
Neighborhood: basic rendering

### DIFF
--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -26,6 +26,7 @@ const timeoutList = require('./timeoutList');
 
 const AnimationsController = require('./animationsController');
 const PegmanController = require('./pegmanController');
+const Pegman = require('./pegman');
 const MazeMap = require('./mazeMap');
 const drawMap = require('./drawMap');
 const getSubtypeForSkin = require('./utils').getSubtypeForSkin;
@@ -389,5 +390,10 @@ module.exports = class MazeController {
   setPegmanD(d, id) {
     const pegman = this.pegmanController.getOrCreatePegman(id);
     pegman.setDirection(d);
+  }
+
+  addPegman(id, x, y, d) {
+    const pegman = new Pegman(id, x, y, d);
+    this.pegmanController.addPegman(pegman);
   }
 };

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -176,6 +176,8 @@ module.exports = class MazeController {
       this.setPegmanX(this.subtype.start.x);
       this.setPegmanY(this.subtype.start.y);
       this.setPegmanD(this.startDirection);
+    } else {
+      // TODO: remove all pegmen except the default
     }
     this.animationsController.reset(first);
 

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -6,7 +6,7 @@ module.exports = class Neighborhood extends Subtype {
   constructor(maze, config = {}) {
     super(maze, config);
     this.spriteMap = this.skin_.spriteMap;
-    this.sheetHeights = this.skin_.sheetHeights;
+    this.sheetRows = this.skin_.sheetRows;
 
     // TODO: these should be defined by the level
     this.initializeWithPlaceholder = true;
@@ -118,6 +118,6 @@ module.exports = class Neighborhood extends Subtype {
 
   // Get dimensions for spritesheet of static images.
   getDimensionsForSheet(sheet) {
-    return [10 * this.squareSize, this.sheetHeights[sheet] * this.squareSize];
+    return [10 * this.squareSize, this.sheetRows[sheet] * this.squareSize];
   }
 }

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -5,8 +5,8 @@ import NeighborhoodDrawer from './neighborhoodDrawer';
 module.exports = class Neighborhood extends Subtype {
   constructor(maze, config = {}) {
     super(maze, config);
-
     this.spriteMap = this.skin_.spriteMap;
+    this.sheetHeights = this.skin_.sheetHeights;
 
     // TODO: these should be defined by the level
     this.initializeWithPlaceholder = true;
@@ -49,24 +49,26 @@ module.exports = class Neighborhood extends Subtype {
     // Compute and draw the tile for each square.
     let tileId = 0;
     this.maze_.map.forEachCell((cell, row, col) => {
-      // each cell with either be a blank tile or an asset tile.
-      // choose based on configuration of tile.
       const asset = this.drawer.getAsset('', row, col);
+
+      // draw blank tile
+      this.drawTile(svg, [0, 0], row, col, tileId);
       if (asset) {
-        // asset is in format {name: <>, sheet: x, row: y, column: z}
-        this.drawTileHelper(
-          asset.sheet, 
-          [asset.row, asset.column], 
+        // add assset on top of blank tile if it exists
+        // asset is in format {name: 'sample name', sheet: x, row: y, column: z}
+        const assetHref = this.skin_.assetUrl(asset.sheet);
+        const [sheetWidth, sheetHeight] = this.getDimensionsForSheet(asset.sheet);
+        this.drawer.drawTileHelper(
+          svg, 
+          [asset.column, asset.row], 
           row, 
           col, 
           tileId, 
-          'auto', 
-          'auto', 
+          assetHref,
+          sheetWidth, 
+          sheetHeight, 
           this.squareSize
         );
-      } else {
-        // draw blank tile
-        this.drawTile(svg, [0, 0], row, col, tileId);
       }
       
       tileId++;
@@ -112,5 +114,10 @@ module.exports = class Neighborhood extends Subtype {
   // Sprite map maps asset ids to sprites within a spritesheet.
   getSpriteMap() {
     return this.spriteMap;
+  }
+
+  // Get dimensions for spritesheet of static images.
+  getDimensionsForSheet(sheet) {
+    return [10 * this.squareSize, this.sheetHeights[sheet] * this.squareSize];
   }
 }

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -6,6 +6,8 @@ module.exports = class Neighborhood extends Subtype {
   constructor(maze, config = {}) {
     super(maze, config);
 
+    this.spriteMap = this.skin_.spriteMap;
+
     // TODO: these should be defined by the level
     this.initializeWithPlaceholder = true;
     this.squareSize = 50;
@@ -47,8 +49,26 @@ module.exports = class Neighborhood extends Subtype {
     // Compute and draw the tile for each square.
     let tileId = 0;
     this.maze_.map.forEachCell((cell, row, col) => {
-      // for now, draw all blank tiles
-      this.drawTile(svg, [0, 0], row, col, tileId);
+      // each cell with either be a blank tile or an asset tile.
+      // choose based on configuration of tile.
+      const asset = this.drawer.getAsset('', row, col);
+      if (asset) {
+        // asset is in format {name: <>, sheet: x, row: y, column: z}
+        this.drawTileHelper(
+          asset.sheet, 
+          [asset.row, asset.column], 
+          row, 
+          col, 
+          tileId, 
+          'auto', 
+          'auto', 
+          this.squareSize
+        );
+      } else {
+        // draw blank tile
+        this.drawTile(svg, [0, 0], row, col, tileId);
+      }
+      
       tileId++;
     });
   }
@@ -57,6 +77,40 @@ module.exports = class Neighborhood extends Subtype {
    * @override 
   **/
   createDrawer(svg) {
-    this.drawer = new NeighborhoodDrawer(this.maze_.map, this.skin_, svg, this.squareSize);
+    this.drawer = new NeighborhoodDrawer(this.maze_.map, this.skin_, svg, this.squareSize, this);
+  }
+
+  /**
+   * Paint the current location of the pegman with id pegmanId.
+   * @param {String} pegmanId
+   * @param {String} color Color to paint current location. 
+   *                       Must be hex code or html color.
+  **/ 
+  addPaint(pegmanId, color) {
+    const col = this.maze_.getPegmanX();
+    const row = this.maze_.getPegmanY();
+
+    const cell = this.getCell(row, col);
+    cell.setColor(color);
+    // TODO: update color on map
+  }
+
+  /**
+   * Remove paint from the location of the pegman with id pegmanId, if there
+   * is any paint.
+   * @param {String} pegmanId
+  **/ 
+ removePaint(pegmanId) {
+    const col = this.maze_.getPegmanX();
+    const row = this.maze_.getPegmanY();
+
+    const cell = this.getCell(row, col);
+    cell.setColor(null);
+    // TODO: remove color from map
+  }
+
+  // Sprite map maps asset ids to sprites within a spritesheet.
+  getSpriteMap() {
+    return this.spriteMap;
   }
 }

--- a/src/neighborhoodCell.js
+++ b/src/neighborhoodCell.js
@@ -2,9 +2,10 @@ const Cell = require('./cell');
 
 module.exports = class NeighborhoodCell extends Cell {
   // value is paint count
-  constructor(tileType, value, hasBucket, color) {
+  constructor(tileType, value, assetId, hasBucket, color) {
     super(tileType, value);
-    this.hasBucket = hasBucket;
+    this.assetId = assetId;
+    this.hasBucket = hasBucket || value > 0;
     this.color = color;
   }
 
@@ -18,5 +19,37 @@ module.exports = class NeighborhoodCell extends Cell {
 
   setColor(color) {
     this.color = color;
+  }
+
+  getAssetId(assetId) {
+    this.assetId = assetId;
+  }
+
+  /**
+   * Serializes this NeighborhoodCell into JSON
+   * @return {Object}
+   * @override
+   */
+  serialize() {
+    return Object.assign({}, super.serialize(), {
+      tileType: this.tileType,
+      value: this.value,
+      assetId: this.assetId,
+      hasBucket: this.hasBucket,
+      color: this.color
+    });
+  }
+
+  /**
+   * @override
+   */
+  static deserialize(serialized) {
+    return new NeighborhoodCell(
+      serialized.tileType,
+      serialized.value,
+      serialized.assetId,
+      serialized.hasBucket,
+      serialized.color
+    );
   }
 }

--- a/src/neighborhoodCell.js
+++ b/src/neighborhoodCell.js
@@ -21,8 +21,8 @@ module.exports = class NeighborhoodCell extends Cell {
     this.color = color;
   }
 
-  getAssetId(assetId) {
-    this.assetId = assetId;
+  getAssetId() {
+    return this.assetId;
   }
 
   /**
@@ -32,8 +32,6 @@ module.exports = class NeighborhoodCell extends Cell {
    */
   serialize() {
     return Object.assign({}, super.serialize(), {
-      tileType: this.tileType,
-      value: this.value,
       assetId: this.assetId,
       hasBucket: this.hasBucket,
       color: this.color

--- a/src/neighborhoodCell.js
+++ b/src/neighborhoodCell.js
@@ -31,11 +31,12 @@ module.exports = class NeighborhoodCell extends Cell {
    * @override
    */
   serialize() {
-    return Object.assign({}, super.serialize(), {
+    return {
+      ...super.serialize(),
       assetId: this.assetId,
       hasBucket: this.hasBucket,
       color: this.color
-    });
+    };
   }
 
   /**

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -2,9 +2,23 @@ const Drawer = require('./drawer')
 
 module.exports = class NeighborhoodDrawer extends Drawer {
 
-  constructor(map, asset, svg, squareSize) {
+  constructor(map, asset, svg, squareSize, neighborhood) {
     super(map, asset, svg);
     this.squareSize = squareSize;
+    this.neighborhood = neighborhood
+  }
+
+  /**
+   * @override
+   */
+  getAsset(prefix, row, col) {
+    const cell = this.neighborhood.getCell(row, col);
+    if (cell.getAssetId() != null) {
+      return this.neighborhood.getSpriteMap()[cell.getAssetId()];
+    } else {
+      // if there's no asset id for the cell, return
+      return;
+    }
   }
 
   /**

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -15,9 +15,6 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     const cell = this.neighborhood.getCell(row, col);
     if (cell.getAssetId() != null) {
       return this.neighborhood.getSpriteMap()[cell.getAssetId()];
-    } else {
-      // if there's no asset id for the cell, return
-      return;
     }
   }
 


### PR DESCRIPTION
This PR adds support for basic rendering of neighborhood maps and adds the plumbing we will need to add and remove paint from the map.

Features included:
- Can deserialize a serialized neighborhood map, which for now must by an 8x8 2d array of objects in the format `{“tileType”:0,“assetId”:18,“value”:0}`, where assetId is optional. `tileType` is an enum used across Maze, we will most likely only user 0 (wall) and 1 (open). `assetId` is used if the tile has any sort of asset on it (trucky, cone, etc.), and it aligns with the neighborhood sprite id mapping defined by curriculum. The value is used if there is a paint bucket on the square, and indicates the number of paint units available.
- Add functions for adding and removing paint, which for now update the `color` field on the cell. This will be expanded on when we add paint glomming.
- Added an `addPegman` function to the mazeController which can be used to add additional pegmen to the maze.

Neighborhood now expects the skin to include an object of `neighborhoodSprites` (see [this PR](https://github.com/code-dot-org/code-dot-org/pull/40543) for initial work on this), as well as an object `sheetRows` in the format: 
```
{
   'other.png': 3,
   'vehicles.png': 7,
    ...
}
```

Where the keys are spritesheet names, and the value is the number of rows in the spritesheet. This is needed for picking out the correct sprite from the spritesheet.  The spritesheets are expected to always have 10 columns.

The display will need some fine-tuning on borders (to be done as a follow-up), but currently looks like this with some hacking on the code-dot-org side:
<img width="399" alt="Screen Shot 2021-05-13 at 11 44 48 AM" src="https://user-images.githubusercontent.com/33666587/118189363-88993200-b3f6-11eb-8c0f-0194a765ef48.png">


## Future Work
- Version up Maze and incorporate these updates with the `code-dot-org` repo.
- Update the `code-dot-org` repo Maze API to use pegman ids and call into paint/neighborhood commands as needed.
- Add any necessary functions to Maze for the management of pegmen in neighborhood--we will definitely need to update reset, because we will need to delete all pegmen on reset. We will also need to add a new function to animationsController for adding a new pegman to the neighborhood.
- Add placeholder pegman capabilities to Maze.