### PR TITLE
Paint Glomming Algorithm

### DIFF
--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -42,10 +42,10 @@ module.exports = class Neighborhood extends Subtype {
   }
 
   /**
-   * 
+   * @override
    * Draw the tiles making up the maze map.
    */
-   drawMapTiles(svg) {
+  drawMapTiles(svg) {
     // Compute and draw the tile for each square.
     let tileId = 0;
     this.maze_.map.forEachCell((cell, row, col) => {

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -103,13 +103,7 @@ module.exports = class Neighborhood extends Subtype {
   paintGlommingDemo(color) {
     this.getCell(0, 0).setColor(color);
     this.getCell(1, 1).setColor(color);
-    this.getCell(0, 1).setColor('green');
-    this.getCell(1, 0).setColor('green');
-    this.getCell(3, 3).setColor('purple');
-    this.getCell(4, 4).setColor('purple');
-    this.getCell(5, 5).setColor('purple');
-    this.getCell(3, 0).setColor('yellow');
-    this.getCell(3, 1).setColor('yellow');
+    this.getCell(2, 2).setColor(color);
     this.drawer.updateItemImage(1, 0, true);
   }
 

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -11,7 +11,6 @@ module.exports = class Neighborhood extends Subtype {
     // TODO: these should be defined by the level
     this.initializeWithPlaceholder = true;
     this.squareSize = 50;
-    this.drawer = null;
   }
 
   /**
@@ -43,11 +42,37 @@ module.exports = class Neighborhood extends Subtype {
   }
 
   /**
-   * @override 
+   * 
    * Draw the tiles making up the maze map.
    */
-  drawMapTiles(svg) {
-    this.drawer.drawMapTiles(svg);
+   drawMapTiles(svg) {
+    // Compute and draw the tile for each square.
+    let tileId = 0;
+    this.maze_.map.forEachCell((cell, row, col) => {
+      const asset = this.drawer.getAsset('', row, col);
+
+      // draw blank tile
+      this.drawTile(svg, [0, 0], row, col, tileId);
+      if (asset) {
+        // add assset on top of blank tile if it exists
+        // asset is in format {name: 'sample name', sheet: x, row: y, column: z}
+        const assetHref = this.skin_.assetUrl(asset.sheet);
+        const [sheetWidth, sheetHeight] = this.getDimensionsForSheet(asset.sheet);
+        this.drawer.drawTileHelper(
+          svg, 
+          [asset.column, asset.row], 
+          row, 
+          col, 
+          tileId, 
+          assetHref,
+          sheetWidth, 
+          sheetHeight, 
+          this.squareSize
+        );
+      }
+      this.drawer.updateItemImage(row, col, true);
+      tileId++;
+    });
   }
 
   /** 

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -72,9 +72,6 @@ module.exports = class Neighborhood extends Subtype {
       }
       tileId++;
     });
-
-    // TODO: remove this demo
-    this.paintGlommingDemo('blue');
   }
 
   /** 
@@ -99,15 +96,6 @@ module.exports = class Neighborhood extends Subtype {
     this.drawer.updateItemImage(row, col, true);
   }
 
-  // This is to show the two steps required to ensure paint is added
-  paintGlommingDemo(color) {
-    this.getCell(0, 0).setColor(color);
-    this.getCell(1, 1).setColor(color);
-    this.getCell(2, 2).setColor(color);
-    this.getCell(7, 7).setColor(color);
-    this.drawer.updateItemImage(1, 0, true);
-  }
-
   /**
    * Remove paint from the location of the pegman with id pegmanId, if there
    * is any paint.
@@ -119,7 +107,7 @@ module.exports = class Neighborhood extends Subtype {
 
     const cell = this.getCell(row, col);
     cell.setColor(null);
-    // TODO: remove color from map
+    this.drawer.updateItemImage(row, col, true);
   }
 
   // Sprite map maps asset ids to sprites within a spritesheet.

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -70,7 +70,6 @@ module.exports = class Neighborhood extends Subtype {
           this.squareSize
         );
       }
-      this.drawer.updateItemImage(row, col, true);
       tileId++;
     });
   }
@@ -95,6 +94,8 @@ module.exports = class Neighborhood extends Subtype {
     const cell = this.getCell(row, col);
     cell.setColor(color);
     // TODO: update color on map
+    this.map_.currentStaticGrid[row][col].originalValue_ = color;
+    this.drawer.updateItemImage(row, col, true);
   }
 
   /**

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -11,6 +11,7 @@ module.exports = class Neighborhood extends Subtype {
     // TODO: these should be defined by the level
     this.initializeWithPlaceholder = true;
     this.squareSize = 50;
+    this.drawer = null;
   }
 
   /**
@@ -46,33 +47,7 @@ module.exports = class Neighborhood extends Subtype {
    * Draw the tiles making up the maze map.
    */
   drawMapTiles(svg) {
-    // Compute and draw the tile for each square.
-    let tileId = 0;
-    this.maze_.map.forEachCell((cell, row, col) => {
-      const asset = this.drawer.getAsset('', row, col);
-
-      // draw blank tile
-      this.drawTile(svg, [0, 0], row, col, tileId);
-      if (asset) {
-        // add assset on top of blank tile if it exists
-        // asset is in format {name: 'sample name', sheet: x, row: y, column: z}
-        const assetHref = this.skin_.assetUrl(asset.sheet);
-        const [sheetWidth, sheetHeight] = this.getDimensionsForSheet(asset.sheet);
-        this.drawer.drawTileHelper(
-          svg, 
-          [asset.column, asset.row], 
-          row, 
-          col, 
-          tileId, 
-          assetHref,
-          sheetWidth, 
-          sheetHeight, 
-          this.squareSize
-        );
-      }
-      
-      tileId++;
-    });
+    this.drawer.drawMapTiles(svg);
   }
 
   /** 

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -72,6 +72,9 @@ module.exports = class Neighborhood extends Subtype {
       }
       tileId++;
     });
+
+    // TODO: remove this demo
+    this.paintGlommingDemo('blue');
   }
 
   /** 
@@ -93,9 +96,21 @@ module.exports = class Neighborhood extends Subtype {
 
     const cell = this.getCell(row, col);
     cell.setColor(color);
-    // TODO: update color on map
-    this.map_.currentStaticGrid[row][col].originalValue_ = color;
+    // TODO: figure out why getCell is broken
+    this.maze_.map.currentStaticGrid[row][col].originalValue_ = color;
     this.drawer.updateItemImage(row, col, true);
+  }
+
+  // This is to show the two steps required to ensure paint is added
+  paintGlommingDemo(color) {
+    this.maze_.map.currentStaticGrid[4][4].originalValue_ = color;
+    this.drawer.updateItemImage(4, 4, true);
+    this.maze_.map.currentStaticGrid[4][5].originalValue_ = color;
+    this.drawer.updateItemImage(4, 5, true);
+    this.maze_.map.currentStaticGrid[5][4].originalValue_ = 'green';
+    this.drawer.updateItemImage(5, 4, true);
+    this.maze_.map.currentStaticGrid[5][5].originalValue_ = 'green';
+    this.drawer.updateItemImage(5, 5, true);
   }
 
   /**

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -96,21 +96,16 @@ module.exports = class Neighborhood extends Subtype {
 
     const cell = this.getCell(row, col);
     cell.setColor(color);
-    // TODO: figure out why getCell is broken
-    this.maze_.map.currentStaticGrid[row][col].originalValue_ = color;
     this.drawer.updateItemImage(row, col, true);
   }
 
   // This is to show the two steps required to ensure paint is added
   paintGlommingDemo(color) {
-    this.maze_.map.currentStaticGrid[4][4].originalValue_ = color;
-    this.drawer.updateItemImage(4, 4, true);
-    this.maze_.map.currentStaticGrid[4][5].originalValue_ = color;
-    this.drawer.updateItemImage(4, 5, true);
-    this.maze_.map.currentStaticGrid[5][4].originalValue_ = 'green';
-    this.drawer.updateItemImage(5, 4, true);
-    this.maze_.map.currentStaticGrid[5][5].originalValue_ = 'green';
-    this.drawer.updateItemImage(5, 5, true);
+    this.getCell(0, 0).setColor(color);
+    this.getCell(1, 1).setColor(color);
+    this.getCell(0, 1).setColor('green');
+    this.getCell(1, 0).setColor('green');
+    this.drawer.updateItemImage(1, 0, true);
   }
 
   /**

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -104,6 +104,7 @@ module.exports = class Neighborhood extends Subtype {
     this.getCell(0, 0).setColor(color);
     this.getCell(1, 1).setColor(color);
     this.getCell(2, 2).setColor(color);
+    this.getCell(7, 7).setColor(color);
     this.drawer.updateItemImage(1, 0, true);
   }
 

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -105,6 +105,11 @@ module.exports = class Neighborhood extends Subtype {
     this.getCell(1, 1).setColor(color);
     this.getCell(0, 1).setColor('green');
     this.getCell(1, 0).setColor('green');
+    this.getCell(3, 3).setColor('purple');
+    this.getCell(4, 4).setColor('purple');
+    this.getCell(5, 5).setColor('purple');
+    this.getCell(3, 0).setColor('yellow');
+    this.getCell(3, 1).setColor('yellow');
     this.drawer.updateItemImage(1, 0, true);
   }
 

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -92,6 +92,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
    * Draw the given tile at row, col
    */
   updateItemImage(r, co, running) {
+    console.log("beginning of update");
 
     let qc = quarterCircle(SQUARE_SIZE);
     let c = cutout(SQUARE_SIZE);
@@ -106,7 +107,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
           this.cellColor(row+1,col+1)];
   
         // Create grid block group
-        let grid = svgElement("grid", {
+        let grid = svgElement("g", {
             transform: `translate(${row * SQUARE_SIZE + SQUARE_SIZE/2}, 
               ${col * SQUARE_SIZE + SQUARE_SIZE/2})`
           }, this.svg_);

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -72,7 +72,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
   }
 
   // Helper method for determining color and path based on neighbors
-  pathCalculator(subjectCell, adjacent1, adjacent2, kitty, transform, grid) {
+  pathCalculator(subjectCell, adjacent1, adjacent2, diagonal, transform, grid) {
     let pie = quarterCircle(SQUARE_SIZE);
     let cutOut = cutout(SQUARE_SIZE);
     let tag = "path";
@@ -83,21 +83,21 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     }
     // Add the cutout if the top left corner has a color and an adjacent cell
     // shares that color, filling in the top left quadrant of the block entirely
-    if (subjectCell && (subjectCell == adjacent1 || subjectCell == adjacent2)) {
+    if (subjectCell && (subjectCell === adjacent1 || subjectCell === adjacent2)) {
       svgElement(tag, {d: cutOut, transform: transform, fill: subjectCell}, grid);
     } 
     // Otherwise, if the two adjacent corners have the same color, add the 
     // cutout shape with that color
-    else if (adjacent1 && adjacent1 == adjacent2 && 
-      ((!kitty || !subjectCell) || subjectCell !== kitty)) {
+    else if (adjacent1 && adjacent1 === adjacent2 && 
+      ((!diagonal || !subjectCell) || subjectCell !== diagonal)) {
       svgElement(tag, {d: cutOut, transform: transform, fill: adjacent1}, grid);
     }
     // Fill in center corner only if an adjacent cell has the same color, or if 
-    // kitty-corner cell is same color and either adjacent is empty
+    // the diagonal cell is same color and either adjacent is empty
     // Note: this handles the "clover case", where we want each
     // cell to "pop" out with its own color if diagonals are matching
-    else if (subjectCell && (adjacent1 == subjectCell || adjacent2 == subjectCell ||
-      (kitty == subjectCell && ((adjacent1 == null || adjacent2 == null) || adjacent1 !== adjacent2)))) {
+    else if (subjectCell && (adjacent1 === subjectCell || adjacent2 === subjectCell ||
+      (diagonal === subjectCell && ((!adjacent1 || !adjacent2) || adjacent1 !== adjacent2)))) {
       svgElement(tag, {d: cutOut, transform: transform, fill: subjectCell}, grid);
     }
   }
@@ -106,7 +106,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
    * @override
    * Draw the given tile at row, col
    */
-   drawTile(svg, tileSheetLocation, row, col, tileId, tileSheetHref) {
+  drawTile(svg, tileSheetLocation, row, col, tileId, tileSheetHref) {
     // we have one background tile for neighborhood (we don't define paths like
     // the other skins). Therefore our 'tile sheet' is just one square.
     const tileSheetWidth = this.squareSize;
@@ -125,7 +125,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     );
   }
 
-    /**
+  /**
    * @override
    * This method is used to display the paint, so has to reprocess the entire grid
    * to get the paint glomming correct
@@ -139,7 +139,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
         /**
          * In a grid of four cells: top left, top right, bottom left, bottom right
-         * So if we are painting cell 0, adjacent cells are 1 & 2, kittycorner is 3
+         * So if we are painting cell 0, adjacent cells are 1 & 2, diagonal is 3
          * +-------+
          * | 0 | 1 |
          * --------

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -92,8 +92,6 @@ module.exports = class NeighborhoodDrawer extends Drawer {
    * Draw the given tile at row, col
    */
   updateItemImage(r, co, running) {
-    console.log("beginning of update");
-
     let qc = quarterCircle(SQUARE_SIZE);
     let c = cutout(SQUARE_SIZE);
     

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -64,6 +64,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
   resetTiles() {}
 
   // Quick helper to retrieve the color stored in this cell
+  // Ensures 'padding cells' (row/col < 0) have no color
   cellColor(row, col) {
     if (row >= this.map_.ROWS || row < 0) return null;
     if (col >= this.map_.COLS || col < 0) return null;
@@ -130,6 +131,9 @@ module.exports = class NeighborhoodDrawer extends Drawer {
    * to get the paint glomming correct
    */
   updateItemImage(r, co, running) {
+
+    // Because this processes a grid of cells at a time, we start at -1 to allow for
+    // a 'padding' row and column with no color.
     for (let row = -1; row < this.map_.ROWS; row++) {
       for (let col = -1; col < this.map_.COLS; col++) {
 

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -1,6 +1,53 @@
-const Drawer = require('./drawer')
+const { SQUARE_SIZE, SVG_NS } = require("./drawer");
+const Subtype = require('./subtype');
 
-module.exports = class NeighborhoodDrawer extends Drawer {
+// World's worst React.createElement, but for SVG
+function svgElement(tag, props, parent) {
+  const element = document.createElementNS(SVG_NS, tag);
+  Object.keys(props).map(function (key) {
+    element.setAttribute(key, props[key])
+  });
+
+  if (parent) {
+    parent.appendChild(el);
+  }
+
+  return element;
+}
+
+// Path drawing a quarter circle
+//    --+
+//  /   |
+//  +---+
+function quarterCircle(size) {
+  let hs = size/2;
+  let cp = size/4;
+  return `m${hs} ${hs}h-${hs}c0-${cp} ${cp}-${hs} ${hs}-${hs}z`;
+}
+
+// Path of the the slice of a square remaining once a quarter circle is 
+// removed from it
+// +----+
+// | /
+// + 
+function cutout(size) {
+  let hs = size / 2;
+  let cp = size / 4;
+  return `m0 0v${hs}c0-${cp} ${cp}-${hs} ${hs}-${hs}z`
+}
+
+
+// Path of the triangular corner
+// +----+
+// |  /
+// | /
+// +
+function corner(size) {
+  let hs = size / 2;
+  return `m${hs} 0h-${hs}v${hs}z`
+}
+
+module.exports = class NeighborhoodDrawer extends Subtype {
 
   constructor(map, asset, svg, squareSize, neighborhood) {
     super(map, asset, svg);
@@ -22,7 +69,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
    * @override
    * Draw the given tile at row, col
    */
-  drawTile(svg, tileSheetLocation, row, col, tileId, tileSheetHref) {
+   drawTile(svg, tileSheetLocation, row, col, tileId, tileSheetHref) {
     // we have one background tile for neighborhood (we don't define paths like
     // the other skins). Therefore our 'tile sheet' is just one square.
     const tileSheetWidth = this.squareSize;
@@ -40,4 +87,100 @@ module.exports = class NeighborhoodDrawer extends Drawer {
       this.squareSize
     );
   }
-}
+
+  resetTiles() {}
+
+  // TODO: There is a way to get the value of a cell reliably but I couldn't
+  // get it to work. This is a workaround method to simplify the logic below
+  cellColor(row, col) {
+    if (row >= this.maze_.map.ROWS) return "none";
+    if (col >= this.maze_.map.COLS) return "none";
+    return this.maze_.map.currentStaticGrid[row][col].originalValue_ || "none";
+  }
+
+  drawMapTiles(svg) {
+    let qc = quarterCircle(SQUARE_SIZE);
+    let c = cutout(SQUARE_SIZE);
+    let co = corner(SQUARE_SIZE);
+    
+    let tileId = 0;
+    for (let row = 0; row < this.maze_.map.ROWS; row++) {
+      for (let col = 0; col < this.maze_.map.COLS; col++) {
+        // Top left, top right, bottom left, bottom right
+        let cells = [
+          this.cellColor(row, col),
+          this.cellColor(row+1, col),
+          this.cellColor(row, col+1),
+          this.cellColor(row+1,col+1)];
+  
+        // Create grid block group
+        let grid = svgElement("grid", {
+            transform: `translate(${row * SQUARE_SIZE + SQUARE_SIZE/2}, 
+              ${col * SQUARE_SIZE + SQUARE_SIZE/2})`
+          }, svg);
+
+        // Add a quarter circle to the top left corner of the block if there is 
+        // a color value there
+        if (cells[0] !== "none") {
+          svgElement("path", {d: qc, fill: cells[0], transform:"rotate(180)"}, grid);
+        }
+
+        // Add a cutout shape if the top left corner has a color and one other
+        // corner shares that color, filling in the top left quadrant of the block
+        // completely
+        if (cells[0] !== "none" && 
+          (cells[0] == cells[1] || cells[0] == cells[2] || cells[0] == cells[3])) {
+            svgElement("path", {d: c, transform: "rotate(180)", fill: cells[0]}, grid);
+
+        // Otherwise, if the two adjacent corners have the same color, add the 
+        // cutout shape with that color
+        } else if (cells[0] == "none" && cells[1] !== "none" && cells[1] == cells[2]) {
+          svgElement("path", {d: c, transform: "rotate(180)", fill: cells[1]}, grid);
+        } else if (cells[0] !== "none" && cells[1] !== "none" && cells[2] !== "none" && cells[3] !== "none") {
+          svgElement("path", {d: c, transform: "rotate(180)", fill: cells[0]}, grid);
+        }
+
+        // The rest of these statements follow the same pattern for each corner
+        // of the block
+        if (cells[1] && cells[1] !== "none") {
+          svgElement("path", {d: qc, fill: cells[1], transform: "rotate(-90)"}, grid);
+        }
+
+        if (cells[1] !== "none" && 
+          (cells[1] == cells[2] || cells[1] == cells[3] || cells[1] == cells[0])) {
+          svgElement("path", {d: c, transform: "rotate(-90)", fill: cells[1]}, grid);
+        } else if (cells[1] == "none" & cells[0] !== "none" && cells[0] == cells[3]) {
+          svgElement("path", {d: c, transform: "rotate(-90)", fill: cells[0]}, grid);
+        } else if (cells[1] !== "none" && cells[0] !== "none" && cells[2] !== "none" && cells[3] !== "none") {
+          svgElement("path", {d: c, transform: "rotate(-90)", fill: cells[1]}, grid);
+        }
+
+        if (cells[2] && cells[2] !== "none") {  
+          svgElement("path", {d: qc, fill: cells[2], transform: "rotate(90)"}, grid);
+        }
+        
+        if (cells[2] !== "none" && 
+          (cells[2] == cells[3] || cells[2] == cells[0] || cells[2] == cells[1])) {
+            svgElement("path", {d: c, transform: "rotate(90)", fill: cells[2]}, grid);
+        } else if (cells[2] == "none" && cells[0] !== "none" && cells[0] == cells[3]) {
+          svgElement("path", {d: c, transform: "rotate(90)", fill: cells[0]}, grid);
+        } else if (cells[2] !== "none" && cells[0] !== "none" && cells[1] !== "none" && cells[3] !== "none") {
+          svgElement("path", {d: c, transform: "rotate(90)", fill: cells[2]}, grid);
+        }
+
+        if (cells[3] && cells[3] !== "none") {
+          svgElement("path", {d: qc, fill: cells[3]}, grid);
+        }
+
+        if (cells[3] !== "none" && 
+          (cells[3] == cells[0] || cells[3] == cells[1] || cells[3] == cells[2])) {
+          svgElement("path", {d: c, fill: cells[3]}, grid);
+        } else if (cells[3] == "none" && cells[1] !== "none" && cells[1] == cells[2]) {
+          svgElement("path", {d: c, fill: cells[1]}, grid);
+        } else if (cells[3] !== "none" && cells[0] !== "none" && cells[1] !== "none" && cells[2] !== "none") {
+          svgElement("path", {d: c,  fill: cells[3]}, grid);
+        }
+      }
+    }
+  }
+};

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -65,9 +65,40 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
   // Quick helper to retrieve the color stored in this cell
   cellColor(row, col) {
-    if (row >= this.map_.ROWS || row < 0) return "none";
-    if (col >= this.map_.COLS || col < 0) return "none";
-    return this.map_.getCell(row, col).getColor() || "none";
+    if (row >= this.map_.ROWS || row < 0) return null;
+    if (col >= this.map_.COLS || col < 0) return null;
+    return this.map_.getCell(row, col).getColor() || null;
+  }
+
+  // Helper method for determining color and path based on neighbors
+  pathCalculator(subjectCell, adjacent1, adjacent2, kitty, transform, grid) {
+    let pie = quarterCircle(SQUARE_SIZE);
+    let cutOut = cutout(SQUARE_SIZE);
+    let tag = "path";
+    // Add a quarter circle to the top left corner of the block if there is 
+    // a color value there
+    if (subjectCell) {
+      svgElement(tag, {d: pie, transform: transform, fill: subjectCell}, grid);
+    }
+    // Add the cutout if the top left corner has a color and an adjacent cell
+    // shares that color, filling in the top left quadrant of the block entirely
+    if (subjectCell && (subjectCell == adjacent1 || subjectCell == adjacent2)) {
+      svgElement(tag, {d: cutOut, transform: transform, fill: subjectCell}, grid);
+    } 
+    // Otherwise, if the two adjacent corners have the same color, add the 
+    // cutout shape with that color
+    else if (adjacent1 && adjacent1 == adjacent2 && 
+      ((!kitty || !subjectCell) || subjectCell !== kitty)) {
+      svgElement(tag, {d: cutOut, transform: transform, fill: adjacent1}, grid);
+    }
+    // Fill in center corner only if an adjacent cell has the same color, or if 
+    // kitty-corner cell is same color and either adjacent is empty
+    // Note: this handles the "clover case", where we want each
+    // cell to "pop" out with its own color if diagonals are matching
+    else if (subjectCell && (adjacent1 == subjectCell || adjacent2 == subjectCell ||
+      (kitty == subjectCell && ((adjacent1 == null || adjacent2 == null) || adjacent1 !== adjacent2)))) {
+      svgElement(tag, {d: cutOut, transform: transform, fill: subjectCell}, grid);
+    }
   }
 
   /**
@@ -95,94 +126,36 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
     /**
    * @override
-   * Draw the given tile at row, col
+   * This method is used to display the paint, so has to reprocess the entire grid
+   * to get the paint glomming correct
    */
   updateItemImage(r, co, running) {
-    let pie = quarterCircle(SQUARE_SIZE);
-    let cutOut = cutout(SQUARE_SIZE);
-    
     for (let row = -1; row < this.map_.ROWS; row++) {
       for (let col = -1; col < this.map_.COLS; col++) {
 
+        /**
+         * In a grid of four cells: top left, top right, bottom left, bottom right
+         * So if we are painting cell 0, adjacent cells are 1 & 2, kittycorner is 3
+         * +-------+
+         * | 0 | 1 |
+         * --------
+         * | 2 | 3 |
+         * +-------+
+         */
         let cells = [
           this.cellColor(row, col),
-          this.cellColor(row+1, col),
           this.cellColor(row, col+1),
+          this.cellColor(row+1, col),
           this.cellColor(row+1,col+1)];
-  
+
         // Create grid block group
         let grid = makeGrid(row, col, this.svg_);
 
-        // Add a quarter circle to the top left corner of the block if there is 
-        // a color value there
-        if (cells[0] !== "none") {
-          svgElement("path", {d: pie, transform: "rotate(180)", fill: cells[0]}, grid);
-        }
-
-        // Add the cutout shape if the top left corner has a color and one other
-        // corner shares that color, filling in the top left quadrant of the block
-        // completely
-        if (cells[0] !== "none" && 
-          (cells[0] == cells[1] || cells[0] == cells[2])) {
-            svgElement("path", {d: cutOut, transform: "rotate(180)", fill: cells[0]}, grid);
-
-        // Otherwise, if the two adjacent corners have the same color, add the 
-        // cutout shape with that color
-        } else if (cells[0] == "none" && cells[1] !== "none" && cells[1] == cells[2]) {
-          svgElement("path", {d: cutOut, transform: "rotate(180)", fill: cells[1]}, grid);
-
-        // Fill in center corner only if an adjacent cell has the same color, or if 
-        // kitty-corner cell is same color and either adjacent is empty
-        // Note: this additional logic handles the "clover case", where we want each
-        // cell to "pop" out with its own color if diagonals are matching
-        } else if (cells[0] !== "none" && (cells[1] == cells[0] || cells[2] == cells[0] || 
-          (cells[3] == cells[0] && (cells[1] == "none" || cells[2] == "none")))) {
-          svgElement("path", {d: cutOut, transform: "rotate(180)", fill: cells[0]}, grid);
-        }
-
-        // The rest of these statements follow the same pattern for each corner
-        // of the block
-        if (cells[1] && cells[1] !== "none") {
-          svgElement("path", {d: pie, transform: "rotate(90)", fill: cells[1]}, grid);
-        }
-
-        if (cells[1] !== "none" && 
-          (cells[1] == cells[3] || cells[1] == cells[0])) {
-          svgElement("path", {d: cutOut, transform: "rotate(90)", fill: cells[1]}, grid);
-        } else if (cells[1] == "none" & cells[0] !== "none" && cells[0] == cells[3]) {
-          svgElement("path", {d: cutOut, transform: "rotate(90)", fill: cells[0]}, grid);
-        } else if (cells[1] !== "none" && (cells[0] == cells[1] || cells[3] == cells[1] ||
-          (cells[2] == cells[1] && (cells[0] == "none" || cells[3] == "none")))) {
-          svgElement("path", {d: cutOut, transform: "rotate(90)", fill: cells[1]}, grid);
-        }
-
-        if (cells[2] && cells[2] !== "none") {  
-          svgElement("path", {d: pie, fill: cells[2], transform: "rotate(-90)"}, grid);
-        }
-        
-        if (cells[2] !== "none" && 
-          (cells[2] == cells[3] || cells[2] == cells[0])) {
-            svgElement("path", {d: cutOut, transform: "rotate(-90)", fill: cells[2]}, grid);
-        } else if (cells[2] == "none" && cells[0] !== "none" && cells[0] == cells[3]) {
-          svgElement("path", {d: cutOut, transform: "rotate(-90)", fill: cells[0]}, grid);
-        } else if (cells[2] !== "none" && (cells[0] == cells[2] || cells[3] == cells[2] ||
-          (cells[2] == cells[1] && (cells[0] == "none" || cells[3] == "none")))) {
-          svgElement("path", {d: cutOut, transform: "rotate(-90)", fill: cells[2]}, grid);
-        }
-
-        if (cells[3] && cells[3] !== "none") {
-          svgElement("path", {d: pie, fill: cells[3]}, grid);
-        }
-
-        if (cells[3] !== "none" && 
-          (cells[3] == cells[1] || cells[3] == cells[2])) {
-          svgElement("path", {d: cutOut, fill: cells[3]}, grid);
-        } else if (cells[3] == "none" && cells[1] !== "none" && cells[1] == cells[2]) {
-          svgElement("path", {d: cutOut, fill: cells[1]}, grid);
-        } else if (cells[3] !== "none" && (cells[1] == cells[3] || cells[2] == cells[3] ||
-          (cells[3] == cells[0] && (cells[1] == "none" || cells[2] == "none")))) {
-          svgElement("path", {d: cutOut,  fill: cells[3]}, grid);
-        }
+        // Calculate all the svg paths based on neighboring cell colors
+        this.pathCalculator(cells[0], cells[1], cells[2], cells[3], "rotate(180)", grid);
+        this.pathCalculator(cells[1], cells[0], cells[3], cells[2], "rotate(-90)", grid);
+        this.pathCalculator(cells[2], cells[0], cells[3], cells[1], "rotate(90)", grid);
+        this.pathCalculator(cells[3], cells[1], cells[2], cells[0], "rotate(0)", grid);
       }
     }
   }


### PR DESCRIPTION
This PR implements the paint glomming algorithm in neighborhoodDrawer. See the below images for examples of all the different glomming configurations!


Jira: https://codedotorg.atlassian.net/browse/CSA-309

![image](https://user-images.githubusercontent.com/37230822/119180940-cf55e000-ba25-11eb-9475-7e1d948a4a2b.png)

![image](https://user-images.githubusercontent.com/37230822/119180966-d977de80-ba25-11eb-8b58-a8d43d99ca29.png)


![image](https://user-images.githubusercontent.com/37230822/118898941-8d605900-b8c2-11eb-9fcb-659878bfc83d.png)

There is currently a demo in neighborhood.js to show how paintGlomming will look and be called using neighborhoodDrawer.

Future work:
1. Hook up pegmen so we have access to the x and y coords and know where to addPaint
2. Get level code to talk to addPaint
3. Figure out animation/speed of this step^
4. Write an entire testing file for NeighborhoodDrawer
5. Fix the pixels-off-by-one error with the resizing ticket: https://codedotorg.atlassian.net/browse/CSA-345