### PR TITLE
Minor updates for fully supporting multiple pegmen

### DIFF
--- a/src/animationsController.js
+++ b/src/animationsController.js
@@ -153,7 +153,7 @@ module.exports = class AnimationsController {
     for (let i = 0; i < paths.length; i++) {
       var path = paths[i];
       path.setAttribute('stroke', this.maze.skin.look);
-      }
+    }
 
     // Reset pegman's visibility if there is only one pegman
     const pegmanIcon = this.getPegmanIcon();

--- a/src/animationsController.js
+++ b/src/animationsController.js
@@ -17,7 +17,7 @@ module.exports = class AnimationsController {
 
   createAnimations_(pegmanId) {
     // Add idle pegman.
-    if (this.maze.skin.idlePegmanAnimation && this.maze.subtype.start) {
+    if (this.maze.skin.idlePegmanAnimation) {
       this.createPegmanAnimation_({
         type: pegmanElements.IDLE,
         pegmanImage: this.maze.skin.idlePegmanAnimation,
@@ -128,8 +128,9 @@ module.exports = class AnimationsController {
         this.scheduleTurn(this.maze.startDirection);
       }, danceTime + 150);
     } else {
-      // Reset the pegman for a maze with 1 pegman. Mazes that allow multiple pegmen will only show/hide a static
-      // default, which is reset by the maze controller.
+      // Reset the pegman for a maze with 1 pegman. Mazes that allow multiple
+      // pegmen will only show/hide a static default, which is 
+      // reset by the maze controller.
       if (!this.maze.subtype.allowMultiplePegmen()) {
         this.displayPegman(this.maze.getPegmanX(), this.maze.getPegmanY(), tiles.directionToFrame(this.maze.getPegmanD()));
       }

--- a/src/animationsController.js
+++ b/src/animationsController.js
@@ -2,6 +2,7 @@ const {SVG_NS, pegmanElements} = require('./constants');
 const drawMap = require('./drawMap');
 const displayPegman = drawMap.displayPegman;
 const getPegmanYForRow = drawMap.getPegmanYForRow;
+const addNewPegman = drawMap.addNewPegman;
 const timeoutList = require('./timeoutList');
 const utils = require('./utils');
 const tiles = require('./tiles');
@@ -16,7 +17,7 @@ module.exports = class AnimationsController {
 
   createAnimations_(pegmanId) {
     // Add idle pegman.
-    if (this.maze.skin.idlePegmanAnimation) {
+    if (this.maze.skin.idlePegmanAnimation && this.maze.subtype.start) {
       this.createPegmanAnimation_({
         type: pegmanElements.IDLE,
         pegmanImage: this.maze.skin.idlePegmanAnimation,
@@ -128,7 +129,7 @@ module.exports = class AnimationsController {
       }, danceTime + 150);
     } else {
       // TODO: reset for mazes with placeholder/multiple pegmen
-      if (!this.maze.subtype.initializeWithPlaceholderPegman() && !this.maze.subtype.allowMultiplePegmen()) {
+      if (!this.maze.subtype.allowMultiplePegmen()) {
         this.displayPegman(this.maze.getPegmanX(), this.maze.getPegmanY(), tiles.directionToFrame(this.maze.getPegmanD()));
       }
       const finishIcon = document.getElementById('finish');
@@ -144,17 +145,21 @@ module.exports = class AnimationsController {
 
     // Make 'look' icon invisible and promote to top.
     var lookIcon = document.getElementById('look');
-    lookIcon.style.display = 'none';
-    lookIcon.parentNode.appendChild(lookIcon);
-    var paths = lookIcon.getElementsByTagName('path');
-    for (let i = 0; i < paths.length; i++) {
-      var path = paths[i];
-      path.setAttribute('stroke', this.maze.skin.look);
+    if (lookIcon) {
+      lookIcon.style.display = 'none';
+      lookIcon.parentNode.appendChild(lookIcon);
+      var paths = lookIcon.getElementsByTagName('path');
+      for (let i = 0; i < paths.length; i++) {
+        var path = paths[i];
+        path.setAttribute('stroke', this.maze.skin.look);
+      }
     }
 
-    // Reset pegman's visibility.
-    var pegmanIcon = this.getPegmanIcon();
-    pegmanIcon.setAttribute('opacity', 1);
+    // Reset pegman's visibility if there is only one pegman
+    if (!this.maze.subtype.allowMultiplePegmen()) {
+      var pegmanIcon = this.getPegmanIcon();
+      pegmanIcon.setAttribute('opacity', 1);
+    }
 
     if (this.maze.skin.idlePegmanAnimation) {
       pegmanIcon.setAttribute('visibility', 'hidden');
@@ -162,7 +167,7 @@ module.exports = class AnimationsController {
         utils.getPegmanElementId(pegmanElements.IDLE)
       );
       idlePegmanIcon.setAttribute('visibility', 'visible');
-    } else {
+    } else if (!this.maze.subtype.allowMultiplePegmen()) {
       pegmanIcon.setAttribute('visibility', 'visible');
     }
 
@@ -576,6 +581,16 @@ module.exports = class AnimationsController {
     }
   }
 
+  hidePegman(pegmanId) {
+    var pegmanIcon = this.getPegmanIcon(pegmanId);
+    pegmanIcon.setAttribute('visibility', 'hidden');
+  }
+
+  showPegman(pegmanId) {
+    var pegmanIcon = this.getPegmanIcon(pegmanId);
+    pegmanIcon.setAttribute('visibility', 'visible');
+  }
+
   /**
    * Schedule the animations and sound for a dance.
    * @param {boolean} victoryDance This is a victory dance after completing the
@@ -700,5 +715,9 @@ module.exports = class AnimationsController {
 
   getPegmanIcon(pegmanId) {
     return document.getElementById(utils.getPegmanElementId(pegmanElements.PEGMAN, pegmanId));
+  }
+
+  addNewPegman(pegmanId, x, y, d) {
+    addNewPegman(this.maze.skin, pegmanId, x, y, d, this.svg);
   }
 };

--- a/src/animationsController.js
+++ b/src/animationsController.js
@@ -128,7 +128,8 @@ module.exports = class AnimationsController {
         this.scheduleTurn(this.maze.startDirection);
       }, danceTime + 150);
     } else {
-      // TODO: reset for mazes with placeholder/multiple pegmen
+      // Reset the pegman for a maze with 1 pegman. Mazes that allow multiple pegmen will only show/hide a static
+      // default, which is reset by the maze controller.
       if (!this.maze.subtype.allowMultiplePegmen()) {
         this.displayPegman(this.maze.getPegmanX(), this.maze.getPegmanY(), tiles.directionToFrame(this.maze.getPegmanD()));
       }

--- a/src/animationsController.js
+++ b/src/animationsController.js
@@ -147,19 +147,17 @@ module.exports = class AnimationsController {
 
     // Make 'look' icon invisible and promote to top.
     var lookIcon = document.getElementById('look');
-    if (lookIcon) {
-      lookIcon.style.display = 'none';
-      lookIcon.parentNode.appendChild(lookIcon);
-      var paths = lookIcon.getElementsByTagName('path');
-      for (let i = 0; i < paths.length; i++) {
-        var path = paths[i];
-        path.setAttribute('stroke', this.maze.skin.look);
+    lookIcon.style.display = 'none';
+    lookIcon.parentNode.appendChild(lookIcon);
+    var paths = lookIcon.getElementsByTagName('path');
+    for (let i = 0; i < paths.length; i++) {
+      var path = paths[i];
+      path.setAttribute('stroke', this.maze.skin.look);
       }
-    }
 
     // Reset pegman's visibility if there is only one pegman
+    const pegmanIcon = this.getPegmanIcon();
     if (!this.maze.subtype.allowMultiplePegmen()) {
-      var pegmanIcon = this.getPegmanIcon();
       pegmanIcon.setAttribute('opacity', 1);
     }
 

--- a/src/drawMap.js
+++ b/src/drawMap.js
@@ -153,3 +153,4 @@ module.exports = function drawMap(svg, skin, subtype, map, squareSize = 50) {
 
 module.exports.getPegmanYForRow = getPegmanYForRow;
 module.exports.displayPegman = displayPegman;
+module.exports.addNewPegman = addNewPegman;

--- a/src/drawMap.js
+++ b/src/drawMap.js
@@ -44,7 +44,8 @@ function addNewPegman(skin, pegmanId, x, y, direction, svg) {
   pegmanIcon.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
     skin.avatar);
   pegmanIcon.setAttribute('height', skin.pegmanHeight);
-  const sheetWidth = skin.pegmanSheetWidth || skin.pegmanWidth * 21 // 49 * 21 = 1029
+  // default pegman sheet has 21 sprites. Skin may override with a specific width for the sheet.
+  const sheetWidth = skin.pegmanSheetWidth || skin.pegmanWidth * 21
   pegmanIcon.setAttribute('width', sheetWidth);
   pegmanIcon.setAttribute('clip-path', `url(#${pegmanClipId})`);
   svg.appendChild(pegmanIcon);

--- a/src/drawMap.js
+++ b/src/drawMap.js
@@ -44,7 +44,8 @@ function addNewPegman(skin, pegmanId, x, y, direction, svg) {
   pegmanIcon.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href',
     skin.avatar);
   pegmanIcon.setAttribute('height', skin.pegmanHeight);
-  pegmanIcon.setAttribute('width', skin.pegmanWidth * 21); // 49 * 21 = 1029
+  const sheetWidth = skin.pegmanSheetWidth || skin.pegmanWidth * 21 // 49 * 21 = 1029
+  pegmanIcon.setAttribute('width', sheetWidth);
   pegmanIcon.setAttribute('clip-path', `url(#${pegmanClipId})`);
   svg.appendChild(pegmanIcon);
 

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -171,6 +171,14 @@ module.exports = class MazeController {
 
     // Kill all tasks.
     timeoutList.clearTimeouts();
+
+    if (this.subtype.start) {
+      // Move default Pegman into position.
+      this.setPegmanX(this.subtype.start.x);
+      this.setPegmanY(this.subtype.start.y);
+      this.setPegmanD(this.startDirection);
+    }
+
     if (this.subtype.allowMultiplePegmen()) {
       // hide all pegman except the default. Show the default if it exists
       const pegmanIds = this.pegmanController.getAllPegmanIds();
@@ -181,12 +189,7 @@ module.exports = class MazeController {
           this.animationsController.hidePegman(pegmanId);
         }
       });
-    } else {
-      // Move Pegman into position.
-      this.setPegmanX(this.subtype.start.x);
-      this.setPegmanY(this.subtype.start.y);
-      this.setPegmanD(this.startDirection);
-    }
+    } 
     this.animationsController.reset(first);
 
     // Move the init dirt marker icons into position.
@@ -426,6 +429,9 @@ module.exports = class MazeController {
   }
 
   hideDefaultPegman() {
-    this.animationsController.hidePegman();
+    // if default pegman exists, hide it
+    if (this.pegmanController.getPegman()) {
+      this.animationsController.hidePegman();
+    }
   }
 };

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -165,8 +165,10 @@ module.exports = class MazeController {
   /**
    * Reset the maze to the start position and kill any pending animation tasks.
    * @param {boolean} first True if an opening animation is to be played.
+   * @param {boolean} showDefault True if the default pegman should be shown. Only applies
+   * to subtypes that allow multiple pegman
    */
-  reset(first) {
+  reset(first, showDefault = true) {
     this.subtype.reset();
 
     // Kill all tasks.
@@ -180,10 +182,11 @@ module.exports = class MazeController {
     }
 
     if (this.subtype.allowMultiplePegmen()) {
-      // hide all pegman except the default. Show the default if it exists
+      // hide all pegman except the default. Show the default if it exists and
+      // showDefault is true
       const pegmanIds = this.pegmanController.getAllPegmanIds();
       pegmanIds.forEach(pegmanId => {
-        if (this.pegmanController.isDefaultPegman(pegmanId)) {
+        if (this.pegmanController.isDefaultPegman(pegmanId) && showDefault) {
           this.animationsController.showPegman(pegmanId);
         } else {
           this.animationsController.hidePegman(pegmanId);

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -172,9 +172,14 @@ module.exports = class MazeController {
     // Kill all tasks.
     timeoutList.clearTimeouts();
     if (this.subtype.allowMultiplePegmen()) {
+      // hide all pegman except the default. Show the default if it exists
       const pegmanIds = this.pegmanController.getAllPegmanIds();
       pegmanIds.forEach(pegmanId => {
-        this.animationsController.hidePegman(pegmanId);
+        if (this.pegmanController.isDefaultPegman(pegmanId)) {
+          this.animationsController.showPegman(pegmanId);
+        } else {
+          this.animationsController.hidePegman(pegmanId);
+        }
       });
     } else {
       // Move Pegman into position.
@@ -418,5 +423,9 @@ module.exports = class MazeController {
       this.pegmanController.addPegman(pegman);
       this.animationsController.addNewPegman(id, x, y, d);
     }
+  }
+
+  hideDefaultPegman() {
+    this.animationsController.hidePegman();
   }
 };

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -186,11 +186,9 @@ module.exports = class MazeController {
       // showDefault is true
       const pegmanIds = this.pegmanController.getAllPegmanIds();
       pegmanIds.forEach(pegmanId => {
-        if (this.pegmanController.isDefaultPegman(pegmanId) && showDefault) {
-          this.animationsController.showPegman(pegmanId);
-        } else {
-          this.animationsController.hidePegman(pegmanId);
-        }
+        this.pegmanController.isDefaultPegman(pegmanId) && showDefault 
+          ? this.animationsController.showPegman(pegmanId) 
+          : this.animationsController.hidePegman(pegmanId);
       });
     } 
     this.animationsController.reset(first);
@@ -428,10 +426,14 @@ module.exports = class MazeController {
       );
       this.animationsController.showPegman(id);
     } else {
-      const pegman = new Pegman(id, x, y, d);
-      this.pegmanController.addPegman(pegman);
-      this.animationsController.addNewPegman(id, x, y, d);
+      this.createAndDisplayPegman(id, x, y, d);
     }
+  }
+
+  createAndDisplayPegman(id, x, y, d) {
+    const pegman = new Pegman(id, x, y, d);
+    this.pegmanController.addPegman(pegman);
+    this.animationsController.addNewPegman(id, x, y, d);
   }
 
   hideDefaultPegman() {

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -406,6 +406,9 @@ module.exports = class MazeController {
   }
 
   addPegman(id, x, y, d) {
+    // if pegman with id <id> already exists, reset 
+    // its location and direction. Otherwise, create a
+    // new pegman and add it to the maze.
     if (this.pegmanController.getPegman(id)) {
       this.animationsController.hidePegman(id);
       const pegman = this.pegmanController.getPegman(id);

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -171,13 +171,16 @@ module.exports = class MazeController {
 
     // Kill all tasks.
     timeoutList.clearTimeouts();
-    // Move Pegman into position.
-    if (!this.subtype.initializeWithPlaceholderPegman()) {
+    if (this.subtype.allowMultiplePegmen()) {
+      const pegmanIds = this.pegmanController.getAllPegmanIds();
+      pegmanIds.forEach(pegmanId => {
+        this.animationsController.hidePegman(pegmanId);
+      });
+    } else {
+      // Move Pegman into position.
       this.setPegmanX(this.subtype.start.x);
       this.setPegmanY(this.subtype.start.y);
       this.setPegmanD(this.startDirection);
-    } else {
-      // TODO: remove all pegmen except the default
     }
     this.animationsController.reset(first);
 
@@ -395,7 +398,25 @@ module.exports = class MazeController {
   }
 
   addPegman(id, x, y, d) {
-    const pegman = new Pegman(id, x, y, d);
-    this.pegmanController.addPegman(pegman);
+    if (this.pegmanController.getPegman(id)) {
+      this.animationsController.hidePegman(id);
+      const pegman = this.pegmanController.getPegman(id);
+        pegman.setX(x);
+        pegman.setY(y);
+        pegman.setDirection(d);
+      
+      var frame = tiles.directionToFrame(d);
+      this.animationsController.displayPegman(
+        x,
+        y,
+        frame,
+        id
+      );
+      this.animationsController.showPegman(id);
+    } else {
+      const pegman = new Pegman(id, x, y, d);
+      this.pegmanController.addPegman(pegman);
+      this.animationsController.addNewPegman(id, x, y, d);
+    }
   }
 };

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -8,8 +8,7 @@ module.exports = class Neighborhood extends Subtype {
     this.spriteMap = this.skin_.spriteMap;
     this.sheetRows = this.skin_.sheetRows;
 
-    // TODO: these should be defined by the level
-    this.initializeWithPlaceholder = true;
+    // TODO: this should be defined by the level
     this.squareSize = 50;
   }
 
@@ -25,13 +24,6 @@ module.exports = class Neighborhood extends Subtype {
    */
   allowMultiplePegmen() {
     return true;
-  }
-
-   /**
-   * @override
-   */
-  initializeWithPlaceholderPegman() {
-    return this.initializeWithPlaceholder;
   }
 
   /**

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -1,4 +1,5 @@
 const Drawer = require('./drawer')
+const tiles = require('./tiles');
 
 module.exports = class NeighborhoodDrawer extends Drawer {
 
@@ -13,7 +14,9 @@ module.exports = class NeighborhoodDrawer extends Drawer {
    */
   getAsset(prefix, row, col) {
     const cell = this.neighborhood.getCell(row, col);
-    if (cell.getAssetId() != null) {
+    // If the tile has an asset id, return the sprite asset. Ignore the asset id
+    // if this is a start tile, as start tiles will handle placing the pegman separately.
+    if (cell.getAssetId() != null && cell.getTile() !== tiles.SquareType.START) {
       return this.neighborhood.getSpriteMap()[cell.getAssetId()];
     }
   }

--- a/src/pegmanController.js
+++ b/src/pegmanController.js
@@ -34,4 +34,8 @@ module.exports =  class PegmanController {
     }
     this.pegmen[pegman.id] = pegman;
   }
+
+  getAllPegmanIds() {
+    return Object.keys(this.pegmen);
+  }
 }

--- a/src/pegmanController.js
+++ b/src/pegmanController.js
@@ -38,4 +38,8 @@ module.exports =  class PegmanController {
   getAllPegmanIds() {
     return Object.keys(this.pegmen);
   }
+
+  isDefaultPegman(pegmanId) {
+    return pegmanId == undefined || pegmanId === DEFAULT_PEGMAN_ID;
+  }
 }

--- a/src/subtype.js
+++ b/src/subtype.js
@@ -244,9 +244,4 @@ module.exports = class Subtype extends EventEmitter {
   allowMultiplePegmen() {
     return false;
   }
-
-  // Whether this subtype should be initialized with a placeholder pegman. Default false.
-  initializeWithPlaceholderPegman() {
-    return false;
-  }
 }


### PR DESCRIPTION
A few updates were needed to fully support our neighborhood subtype and its ability to render multiple pegmen. The main change here is getting rid of the concept of a separate placeholder pegman. It was much easier to use the default pegman in this case for neighborhood levels which designate a start location. The default pegman in this case will optionally show up on reset (there's a new parameter to control this), and can be hidden with a new `hidePegman` function, which code-dot-org will call when it starts running a student program.

Other changes include:
- avoiding some null references for icons we aren't using for neighborhood by adding additional if statements
- adding functions to the `animationsController` to add new pegmen as needed, as well as show/hide a pegman by its id
- support a custom width of a pegman spritesheet (the current code expected a 21 sprite wide sheet)
- for neighborhood, ignore any assets on a start location, as any asset would be the painter, and that will be handled separately by the pegman logic.