### PR TITLE
Add and Remove Paint commands in Maze

### DIFF
--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -9,7 +9,7 @@ module.exports = class Neighborhood extends Subtype {
     this.sheetRows = this.skin_.sheetRows;
 
     // TODO: this should be defined by the level
-    this.squareSize = 32;
+    this.squareSize = 50;
   }
 
   /**
@@ -80,8 +80,8 @@ module.exports = class Neighborhood extends Subtype {
    *                       Must be hex code or html color.
   **/ 
   addPaint(pegmanId, color) {
-    const col = this.maze_.getPegmanX();
-    const row = this.maze_.getPegmanY();
+    const col = this.maze_.getPegmanX(pegmanId);
+    const row = this.maze_.getPegmanY(pegmanId);
 
     const cell = this.getCell(row, col);
     cell.setColor(color);
@@ -94,11 +94,12 @@ module.exports = class Neighborhood extends Subtype {
    * @param {String} pegmanId
   **/ 
  removePaint(pegmanId) {
-    const col = this.maze_.getPegmanX();
-    const row = this.maze_.getPegmanY();
+    const col = this.maze_.getPegmanX(pegmanId);
+    const row = this.maze_.getPegmanY(pegmanId);
 
     const cell = this.getCell(row, col);
     cell.setColor(null);
+    this.maze_.reset;
     this.drawer.updateItemImage(row, col, true);
   }
 

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -99,7 +99,7 @@ module.exports = class Neighborhood extends Subtype {
 
     const cell = this.getCell(row, col);
     cell.setColor(null);
-    this.maze_.reset;
+    this.drawer.resetTile(row, col);
     this.drawer.updateItemImage(row, col, true);
   }
 

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -9,7 +9,7 @@ module.exports = class Neighborhood extends Subtype {
     this.sheetRows = this.skin_.sheetRows;
 
     // TODO: this should be defined by the level
-    this.squareSize = 50;
+    this.squareSize = 32;
   }
 
   /**

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -1,4 +1,3 @@
-const { NeighborhoodSignalType } = require("../../apps/src/javalab/constants");
 const { SQUARE_SIZE, SVG_NS } = require("./drawer");
 const Drawer = require('./drawer')
 const tiles = require('./tiles');
@@ -75,7 +74,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
       if (node) {
         node.querySelectorAll('*').forEach(n => n.remove());
       }
-    };
+    }
   }
 
   /**

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -12,10 +12,10 @@ const PIE = "pie";
 // Helper for creating SVG elements
 function svgElement(tag, props, parent, id) {
   var node = document.getElementById(id);
-    if (!node) {
-      node = document.createElementNS(SVG_NS, tag);
-      node.setAttribute("id", id);
-    }
+  if (!node) {
+    node = document.createElementNS(SVG_NS, tag);
+    node.setAttribute("id", id);
+  }
   Object.keys(props).map(function (key) {
     node.setAttribute(key, props[key])
   });
@@ -108,18 +108,18 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     // Add a quarter circle to the top left corner of the block if there is 
     // a color value there
     if (subjectCell) {
-      svgElement(tag, {d: pie, stroke: subjectCell, transform: transform, fill: subjectCell}, grid, id + PIE);
+      svgElement(tag, {d: pie, stroke: subjectCell, transform: transform, fill: subjectCell}, grid, `${id}-${PIE}`);
     }
     // Add the cutout if the top left corner has a color and an adjacent cell
     // shares that color, filling in the top left quadrant of the block entirely
     if (subjectCell && (subjectCell === adjacent1 || subjectCell === adjacent2)) {
-      svgElement(tag, {d: cutOut, stroke: subjectCell, transform: transform, fill: subjectCell}, grid, id + CUT);
+      svgElement(tag, {d: cutOut, stroke: subjectCell, transform: transform, fill: subjectCell}, grid, `${id}-${CUT}`);
     } 
     // Otherwise, if the two adjacent corners have the same color, add the 
     // cutout shape with that color
     else if (adjacent1 && adjacent1 === adjacent2 && 
       ((!diagonal || !subjectCell) || subjectCell !== diagonal)) {
-      svgElement(tag, {d: cutOut, stroke: adjacent1, transform: transform, fill: adjacent1}, grid, id + CUT);
+      svgElement(tag, {d: cutOut, stroke: adjacent1, transform: transform, fill: adjacent1}, grid, `${id}-${CUT}`);
     }
     // Fill in center corner only if an adjacent cell has the same color, or if 
     // the diagonal cell is same color and either adjacent is empty
@@ -127,7 +127,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     // cell to "pop" out with its own color if diagonals are matching
     else if (subjectCell && (adjacent1 === subjectCell || adjacent2 === subjectCell ||
       (diagonal === subjectCell && ((!adjacent1 || !adjacent2) || adjacent1 !== adjacent2)))) {
-      svgElement(tag, {d: cutOut, stroke: subjectCell, transform: transform, fill: subjectCell}, grid, id + CUT);
+      svgElement(tag, {d: cutOut, stroke: subjectCell, transform: transform, fill: subjectCell}, grid, `${id}-${CUT}`);
     }
   }
 

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -64,8 +64,6 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     }
   }
 
-  resetTiles() {}
-
   // Quick helper to retrieve the color stored in this cell
   // Ensures 'padding cells' (row/col < 0) have no color
   cellColor(row, col) {

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -80,7 +80,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
   /**
    * @override
-   */
+  */
   getAsset(prefix, row, col) {
     const cell = this.neighborhood.getCell(row, col);
     // If the tile has an asset id, return the sprite asset. Ignore the asset id
@@ -89,6 +89,8 @@ module.exports = class NeighborhoodDrawer extends Drawer {
       return this.neighborhood.getSpriteMap()[cell.getAssetId()];
     }
   }
+
+  resetTiles() {}
 
   // Quick helper to retrieve the color stored in this cell
   // Ensures 'padding cells' (row/col < 0) have no color

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -1,19 +1,29 @@
+const { NeighborhoodSignalType } = require("../../apps/src/javalab/constants");
 const { SQUARE_SIZE, SVG_NS } = require("./drawer");
 const Drawer = require('./drawer')
 const tiles = require('./tiles');
 
+const ROTATE180 = "rotate(180)";
+const ROTATENEG90 = "rotate(-90)";
+const ROTATE90 = "rotate(90)";
+const ROTATE0 = "rotate(0)";
+const CUT = "cut";
+const PIE = "pie";
+
 // Helper for creating SVG elements
-function svgElement(tag, props, parent) {
-  const element = document.createElementNS(SVG_NS, tag);
+function svgElement(tag, props, parent, id) {
+  var node = document.getElementById(id);
+    if (!node) {
+      node = document.createElementNS(SVG_NS, tag);
+      node.setAttribute("id", id);
+    }
   Object.keys(props).map(function (key) {
-    element.setAttribute(key, props[key])
+    node.setAttribute(key, props[key])
   });
-
   if (parent) {
-    parent.appendChild(element);
+    parent.appendChild(node);
   }
-
-  return element;
+  return node;
 }
 
 // Path drawing a quarter circle
@@ -38,10 +48,11 @@ function cutout(size) {
 }
 
 function makeGrid(row, col, svg) {
+  let id = "g" + row + "." + col;
   return svgElement("g", {
     transform: `translate(${col * SQUARE_SIZE + SQUARE_SIZE}, 
       ${row * SQUARE_SIZE + SQUARE_SIZE})`
-  }, svg);
+  }, svg, id);
 }
 
 module.exports = class NeighborhoodDrawer extends Drawer {
@@ -50,6 +61,21 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     super(map, asset, svg);
     this.squareSize = squareSize;
     this.neighborhood = neighborhood
+  }
+
+  resetTile(row, col) {
+    let neighbors = [
+      "g" + row + "." + col,
+      "g" + (row - 1) + "." + (col - 1),
+      "g" + row + "." + (col - 1),
+      "g" + (row - 1) + "." + col
+    ];
+    for (const neighbor of neighbors) {
+      var node = document.getElementById(neighbor);
+      if (node) {
+        node.querySelectorAll('*').forEach(n => n.remove());
+      }
+    };
   }
 
   /**
@@ -73,25 +99,26 @@ module.exports = class NeighborhoodDrawer extends Drawer {
   }
 
   // Helper method for determining color and path based on neighbors
-  pathCalculator(subjectCell, adjacent1, adjacent2, diagonal, transform, grid) {
+  pathCalculator(subjectCell, adjacent1, adjacent2, diagonal, transform, grid, id) {
     let pie = quarterCircle(SQUARE_SIZE);
     let cutOut = cutout(SQUARE_SIZE);
     let tag = "path";
+
     // Add a quarter circle to the top left corner of the block if there is 
     // a color value there
     if (subjectCell) {
-      svgElement(tag, {d: pie, transform: transform, fill: subjectCell}, grid);
+      svgElement(tag, {d: pie, stroke: subjectCell, transform: transform, fill: subjectCell}, grid, id + PIE);
     }
     // Add the cutout if the top left corner has a color and an adjacent cell
     // shares that color, filling in the top left quadrant of the block entirely
     if (subjectCell && (subjectCell === adjacent1 || subjectCell === adjacent2)) {
-      svgElement(tag, {d: cutOut, transform: transform, fill: subjectCell}, grid);
+      svgElement(tag, {d: cutOut, stroke: subjectCell, transform: transform, fill: subjectCell}, grid, id + CUT);
     } 
     // Otherwise, if the two adjacent corners have the same color, add the 
     // cutout shape with that color
     else if (adjacent1 && adjacent1 === adjacent2 && 
       ((!diagonal || !subjectCell) || subjectCell !== diagonal)) {
-      svgElement(tag, {d: cutOut, transform: transform, fill: adjacent1}, grid);
+      svgElement(tag, {d: cutOut, stroke: adjacent1, transform: transform, fill: adjacent1}, grid, id + CUT);
     }
     // Fill in center corner only if an adjacent cell has the same color, or if 
     // the diagonal cell is same color and either adjacent is empty
@@ -99,7 +126,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     // cell to "pop" out with its own color if diagonals are matching
     else if (subjectCell && (adjacent1 === subjectCell || adjacent2 === subjectCell ||
       (diagonal === subjectCell && ((!adjacent1 || !adjacent2) || adjacent1 !== adjacent2)))) {
-      svgElement(tag, {d: cutOut, transform: transform, fill: subjectCell}, grid);
+      svgElement(tag, {d: cutOut, stroke: subjectCell, transform: transform, fill: subjectCell}, grid, id + CUT);
     }
   }
 
@@ -151,16 +178,23 @@ module.exports = class NeighborhoodDrawer extends Drawer {
           this.cellColor(row, col),
           this.cellColor(row, col+1),
           this.cellColor(row+1, col),
-          this.cellColor(row+1,col+1)];
+          this.cellColor(row+1,col+1)
+        ];
 
-        // Create grid block group
-        let grid = makeGrid(row, col, this.svg_);
+        if (cells[0] || cells[1] || cells[2] || cells[3]) {
+          // Create grid block group
+          let grid = makeGrid(row, col, this.svg_);
+          let id0 = row + "." + col + "." + ROTATE180;
+          let id1 = row + "." + col + "." + ROTATENEG90;
+          let id2 = row + "." + col + "." + ROTATE90;
+          let id3 = row + "." + col + "." + ROTATE0;
 
-        // Calculate all the svg paths based on neighboring cell colors
-        this.pathCalculator(cells[0], cells[1], cells[2], cells[3], "rotate(180)", grid);
-        this.pathCalculator(cells[1], cells[0], cells[3], cells[2], "rotate(-90)", grid);
-        this.pathCalculator(cells[2], cells[0], cells[3], cells[1], "rotate(90)", grid);
-        this.pathCalculator(cells[3], cells[1], cells[2], cells[0], "rotate(0)", grid);
+          // Calculate all the svg paths based on neighboring cell colors
+          this.pathCalculator(cells[0], cells[1], cells[2], cells[3], ROTATE180, grid, id0);
+          this.pathCalculator(cells[1], cells[0], cells[3], cells[2], ROTATENEG90, grid, id1);
+          this.pathCalculator(cells[2], cells[0], cells[3], cells[1], ROTATE90, grid, id2);
+          this.pathCalculator(cells[3], cells[1], cells[2], cells[0], ROTATE0, grid, id3);
+        }
       }
     }
   }


### PR DESCRIPTION
This PR accomplishes the addPaint() and removePaint() functionality, and also corrects a bug and optimizes the glomming algorithm. 

Updates: 
1. All svg elements now have unique Id's, allowing us to access and alter them as needed
2. No more duplicate elements!
3. We only create a grid group if there is a path that needs to be drawn, bringing our node count from the 1000's to the 10's. 
4. The paint gaps/empty pixel lines are filled in
5. General refactoring/readibility
6. We now have a reset function that will reset tiles and their neighboring elements, which is used in removePaint().

A video of new functionality and the conversation with Hannah is in this slack thread:
https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1622072765148500

Jira Task: https://codedotorg.atlassian.net/browse/CSA-354

Future work:
1. Make the painter sit on top of the paint https://codedotorg.atlassian.net/browse/CSA-368
2. Unit test https://codedotorg.atlassian.net/browse/CSA-360
3. Potentially make it so adding a new color of paint automatically "scrapes" the old paint below (pending Hannah W. feedback)