### PR TITLE
Support specifying square and svg sizes

### DIFF
--- a/src/animationsController.js
+++ b/src/animationsController.js
@@ -217,7 +217,7 @@ module.exports = class AnimationsController {
       rect.setAttribute('x', options.col * this.maze.SQUARE_SIZE + 1 + this.maze.PEGMAN_X_OFFSET);
     }
     if (options.row !== undefined) {
-      rect.setAttribute('y', getPegmanYForRow(this.maze.skin, options.row));
+      rect.setAttribute('y', getPegmanYForRow(this.maze.skin, options.row, this.maze.SQUARE_SIZE));
     }
     rect.setAttribute('width', this.maze.PEGMAN_WIDTH);
     rect.setAttribute('height', this.maze.PEGMAN_HEIGHT);
@@ -240,7 +240,7 @@ module.exports = class AnimationsController {
       img.setAttribute('x', x);
     }
     if (options.row !== undefined) {
-      img.setAttribute('y', getPegmanYForRow(this.maze.skin, options.row));
+      img.setAttribute('y', getPegmanYForRow(this.maze.skin, options.row, this.maze.SQUARE_SIZE));
     }
   }
 
@@ -266,12 +266,12 @@ module.exports = class AnimationsController {
   updatePegmanAnimation_(options) {
     var rect = document.getElementById(utils.getPegmanElementId(`${options.type}ClipRect`, options.pegmanId));
     rect.setAttribute('x', options.col * this.maze.SQUARE_SIZE + 1 + this.maze.PEGMAN_X_OFFSET);
-    rect.setAttribute('y', getPegmanYForRow(this.maze.skin, options.row));
+    rect.setAttribute('y', getPegmanYForRow(this.maze.skin, options.row, this.maze.SQUARE_SIZE));
     var img = document.getElementById(utils.getPegmanElementId(options.type, options.pegmanId));
     var x = this.maze.SQUARE_SIZE * options.col -
         options.direction * this.maze.PEGMAN_WIDTH + 1 + this.maze.PEGMAN_X_OFFSET;
     img.setAttribute('x', x);
-    var y = getPegmanYForRow(this.maze.skin, options.row) - this.getPegmanFrameOffsetY_(options.animationRow);
+    var y = getPegmanYForRow(this.maze.skin, options.row, this.maze.SQUARE_SIZE) - this.getPegmanFrameOffsetY_(options.animationRow);
     img.setAttribute('y', y);
     img.setAttribute('visibility', 'visible');
   }
@@ -710,7 +710,7 @@ module.exports = class AnimationsController {
   displayPegman(x, y, frame, pegmanId) {
     var pegmanIcon = this.getPegmanIcon(pegmanId);
     var clipRect = document.getElementById(utils.getPegmanElementId(pegmanElements.CLIP_RECT, pegmanId));
-    displayPegman(this.maze.skin, pegmanIcon, clipRect, x, y, frame);
+    displayPegman(this.maze.skin, pegmanIcon, clipRect, x, y, frame, this.maze.SQUARE_SIZE);
   }
 
   getPegmanIcon(pegmanId) {
@@ -718,6 +718,6 @@ module.exports = class AnimationsController {
   }
 
   addNewPegman(pegmanId, x, y, d) {
-    addNewPegman(this.maze.skin, pegmanId, x, y, d, this.svg);
+    addNewPegman(this.maze.skin, pegmanId, x, y, d, this.svg, this.maze.SQUARE_SIZE);
   }
 };

--- a/src/drawMap.js
+++ b/src/drawMap.js
@@ -20,13 +20,13 @@ function displayPegman(skin, pegmanIcon, clipRect, x, y, frame, squareSize = 50)
   const xOffset = skin.pegmanXOffset || 0;
   pegmanIcon.setAttribute('x',
     x * squareSize - frame * skin.pegmanWidth + 1 + xOffset);
-  pegmanIcon.setAttribute('y', getPegmanYForRow(skin, y));
+  pegmanIcon.setAttribute('y', getPegmanYForRow(skin, y, squareSize));
 
   clipRect.setAttribute('x', x * squareSize + 1 + xOffset);
   clipRect.setAttribute('y', pegmanIcon.getAttribute('y'));
 }
 
-function addNewPegman(skin, pegmanId, x, y, direction, svg) {
+function addNewPegman(skin, pegmanId, x, y, direction, svg, squareSize = 50) {
   // Pegman's clipPath element, whose (x, y) is reset by Maze.displayPegman
   const pegmanClip = document.createElementNS(SVG_NS, 'clipPath');
   const pegmanClipId = `pegmanClipPath-${createUuid()}`;
@@ -51,7 +51,7 @@ function addNewPegman(skin, pegmanId, x, y, direction, svg) {
   svg.appendChild(pegmanIcon);
 
   displayPegman(skin, pegmanIcon, clipRect, x, y,
-    tiles.directionToFrame(direction));
+    tiles.directionToFrame(direction), squareSize);
 
   
   var pegmanFadeoutAnimation = document.createElementNS(SVG_NS, 'animate');
@@ -104,7 +104,7 @@ module.exports = function drawMap(svg, skin, subtype, map, squareSize = 50) {
   svg.appendChild(hintPath);
 
   if (subtype.start) {
-    addNewPegman(skin, undefined, subtype.start.x, subtype.start.y, subtype.startDirection, svg);
+    addNewPegman(skin, undefined, subtype.start.x, subtype.start.y, subtype.startDirection, svg, squareSize);
   }
 
   if (subtype.finish && skin.goalIdle) {

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -123,14 +123,14 @@ module.exports = class MazeController {
     }
 
     // Pixel height and width of each maze square (i.e. tile).
-    this.SQUARE_SIZE = 50;
+    this.SQUARE_SIZE = this.skin.squareSize  || 50;
     this.PEGMAN_HEIGHT = this.skin.pegmanHeight;
     this.PEGMAN_WIDTH = this.skin.pegmanWidth;
     this.PEGMAN_X_OFFSET = this.skin.pegmanXOffset || 0;
     this.PEGMAN_Y_OFFSET = this.skin.pegmanYOffset;
 
-    this.MAZE_WIDTH = this.SQUARE_SIZE * this.map.COLS;
-    this.MAZE_HEIGHT = this.SQUARE_SIZE * this.map.ROWS;
+    this.MAZE_WIDTH = this.skin.mazeWidth || this.SQUARE_SIZE * this.map.COLS;
+    this.MAZE_HEIGHT = this.skin.mazeHeight || this.SQUARE_SIZE * this.map.ROWS;
     this.PATH_WIDTH = this.SQUARE_SIZE / 3;
   }
 

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -54,6 +54,8 @@ module.exports = class MazeController {
     this.PEGMAN_X_OFFSET = null;
     this.PEGMAN_Y_OFFSET = null;
     this.SQUARE_SIZE = null;
+    this.SVG_WIDTH = null;
+    this.SVG_HEIGHT = null;
 
     if (options.methods) {
       this.rebindMethods(options.methods);
@@ -80,9 +82,18 @@ module.exports = class MazeController {
   }
 
   initWithSvg(svg) {
-    // Adjust outer element size.
-    svg.setAttribute('width', this.MAZE_WIDTH);
-    svg.setAttribute('height', this.MAZE_HEIGHT);
+    // Adjust outer element size to desired size of overall SVG.
+    // This may be equal to the 'actual' maze size 
+    // (square size * num_columns x square size * num_rows)
+    // if no svg size was provided by the skin.
+    svg.setAttribute('width', this.SVG_WIDTH);
+    svg.setAttribute('height', this.SVG_HEIGHT);
+    // Adjust view box. View box width and height are the 'actual' maze dimensions.
+    // This attribute combined with the width and height will scale the svg to our
+    // desired size. We want to maintain the top corner location, so the min-x 
+    // and min-y values are set to 0.
+    // See view box explanation here: https://css-tricks.com/scale-svg/
+    svg.setAttribute('viewBox', `0 0 ${this.MAZE_WIDTH} ${this.MAZE_HEIGHT}`);
 
     drawMap(svg, this.skin, this.subtype, this.map, this.SQUARE_SIZE);
     this.animationsController = new AnimationsController(this, svg);
@@ -129,8 +140,11 @@ module.exports = class MazeController {
     this.PEGMAN_X_OFFSET = this.skin.pegmanXOffset || 0;
     this.PEGMAN_Y_OFFSET = this.skin.pegmanYOffset;
 
-    this.MAZE_WIDTH = this.skin.mazeWidth || this.SQUARE_SIZE * this.map.COLS;
-    this.MAZE_HEIGHT = this.skin.mazeHeight || this.SQUARE_SIZE * this.map.ROWS;
+    this.MAZE_WIDTH = this.SQUARE_SIZE * this.map.COLS;
+    this.MAZE_HEIGHT = this.SQUARE_SIZE * this.map.ROWS;
+    this.SVG_WIDTH = this.skin.svgWidth || this.MAZE_WIDTH;
+    this.SVG_HEIGHT = this.skin.svgHeight || this.MAZE_HEIGHT;
+
     this.PATH_WIDTH = this.SQUARE_SIZE / 3;
   }
 

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -8,8 +8,7 @@ module.exports = class Neighborhood extends Subtype {
     this.spriteMap = this.skin_.spriteMap;
     this.sheetRows = this.skin_.sheetRows;
 
-    // TODO: this should be defined by the level
-    this.squareSize = 50;
+    this.squareSize = this.skin_.squareSize;
   }
 
   /**


### PR DESCRIPTION
For the neighborhood subtype, we want to support grid sizes from 8x8 -> 32 x32 and square sizes other than 50 px squares (in order to support sprites that are not 50x50).  Currently Maze makes no assumptions about the number of rows and columns in a maze, but does assume 50px squares in a few places, and calculates the size of the overall maze based on square_size * rows x square_size * columns. We want to support setting the square size based on the skin, and scaling the overall maze svg to fit whatever dimensions we want to put the maze in.

To support this, we add 3 new variables that get passed via the skin. They are `squareSize`, `svgHeight` and `svgWidth`. If they are not provided, we default to size 50 squares, with height and width calculated based on squares times number of rows or columns. The size of our overall svg will be determined by svgHeight and svgWidth, and we add a [viewBox](https://css-tricks.com/scale-svg/) around the maze with the actual size of the maze (square_size * columns x square_size * rows).

For example, for Neighborhood we will provide the svg height and width as 400 px and the square_size as 32 (the size of our sprites). The height and width attributes on the overall svg will be 400, but the view box dimensions will vary based on the dimensions of the maze. For an 8x8 grid, the viewBox will be `0 0 256 256`, for a 16x16 grid, the viewBox will be `0 0 512 512`, and so on.

This PR also ensures that everywhere we reference a squareSize we pass in the appropriate variable, defaulting to 50 if that variable is undefined.
