### PR TITLE
Moving Painter to the top of the display

### DIFF
--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -9,7 +9,19 @@ const ROTATE0 = "rotate(0)";
 const CUT = "cut";
 const PIE = "pie";
 
-// Helper for creating SVG elements
+/**
+ * This is a helper for creating SVG Elements. 
+ * Groups are created by grid tile, under which paths are nested. These groups
+ * begin with "g" in the id. By checking for this when determining its position
+ * within the hierarchy, we can nest these groups just before the pegman,
+ * insuring the pegman will appear on top of the paint.
+ * 
+ * @param tag representing the element type, 'g' for group, 'path' for paths
+ * @param props representing the details of the element
+ * @param parent the parent it should be nested under
+ * @param id the unique identifier, beginning with 'g' if a group element
+ * @returns the element itself
+ */
 function svgElement(tag, props, parent, id) {
   var node = document.getElementById(id);
   if (!node) {
@@ -19,7 +31,11 @@ function svgElement(tag, props, parent, id) {
   Object.keys(props).map(function (key) {
     node.setAttribute(key, props[key])
   });
-  if (parent) {
+  if (parent && id.startsWith("g")) {
+    let pegmanElement = parent.getElementsByClassName('pegman-location')[0];
+    parent.insertBefore(node, pegmanElement);
+  }
+  else if (parent) {
     parent.appendChild(node);
   }
   return node;
@@ -46,6 +62,7 @@ function cutout(size) {
   return `m0 0v${halfSize}c0-${quarterSize} ${quarterSize}-${halfSize} ${halfSize}-${halfSize}z`
 }
 
+// For creating the groups for each grid location
 function makeGrid(row, col, svg) {
   let id = "g" + row + "." + col;
   return svgElement("g", {
@@ -54,6 +71,11 @@ function makeGrid(row, col, svg) {
   }, svg, id);
 }
 
+/**
+ * This drawer hosts all paint glomming logic. As a rule: paint glomming will
+ * work as expected as long as old colors are erased/scraped first. Otherwise,
+ * new colors will layer on top of old paint.
+ */
 module.exports = class NeighborhoodDrawer extends Drawer {
 
   constructor(map, asset, svg, squareSize, neighborhood) {
@@ -79,7 +101,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
   /**
    * @override
-  */
+   */
   getAsset(prefix, row, col) {
     const cell = this.neighborhood.getCell(row, col);
     // If the tile has an asset id, return the sprite asset. Ignore the asset id

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -14,7 +14,7 @@ const PIE = "pie";
  * Groups are created by grid tile, under which paths are nested. These groups
  * begin with "g" in the id. By checking for this when determining its position
  * within the hierarchy, we can nest these groups just before the pegman,
- * insuring the pegman will appear on top of the paint.
+ * ensuring the pegman will appear on top of the paint.
  * 
  * @param tag representing the element type, 'g' for group, 'path' for paths
  * @param props representing the details of the element
@@ -72,9 +72,12 @@ function makeGrid(row, col, svg) {
 }
 
 /**
- * This drawer hosts all paint glomming logic. As a rule: paint glomming will
- * work as expected as long as old colors are erased/scraped first. Otherwise,
- * new colors will layer on top of old paint.
+ * This drawer hosts all paint glomming logic. 
+ * A note on layering paint: If paint is applied on top of existing paint 
+ * (that has not been removed/scraped), portions of the cell might still
+ * display the first layer of paint. Example: [blue][blue] in layer 1 will
+ * create a "pill" visual. If the second cell is then painted [yellow], the
+ * yellow circle will appear on top, with the blue cutouts still visible below.
  */
 module.exports = class NeighborhoodDrawer extends Drawer {
 


### PR DESCRIPTION
This PR includes both documentation for Paint Glomming layering (slack conversation below) and update to svg element creator, moving the groups of paths before the painter, ensuring the painter will always display on top.

Group elements are given a unique id beginning with "g", which is what I use to check where the child should be nested. If the element is a path element, its id will ensure it's nested directly under its parent group element.

https://codedotorg.slack.com/archives/C01EF4GJ9GE/p1622137178159700?thread_ts=1622072765.148500&cid=C01EF4GJ9GE

![image](https://user-images.githubusercontent.com/37230822/119883992-03794700-bee5-11eb-896b-1799eafc81cb.png)

Jira: https://codedotorg.atlassian.net/browse/CSA-368