### PR TITLE
Neighborhood: add paint buckets

### DIFF
--- a/src/drawer.js
+++ b/src/drawer.js
@@ -51,8 +51,8 @@ module.exports = class Drawer {
    * @param {number} col
    * @param {boolean} running
    */
-  updateItemImage(row, col, running) {
-    return this.drawImage_('', row, col);
+  updateItemImage(row, col, running, squareSize = SQUARE_SIZE) {
+    return this.drawImage_('', row, col, squareSize);
   }
 
   /**
@@ -62,7 +62,7 @@ module.exports = class Drawer {
    * @param {number} col
    * @return {Element} img
    */
-  drawImage_(prefix, row, col) {
+  drawImage_(prefix, row, col, squareSize = SQUARE_SIZE) {
     let img = this.svg_.querySelector('#' + Drawer.cellId(prefix, row, col));
     let href = this.getAsset(prefix, row, col);
 
@@ -75,7 +75,7 @@ module.exports = class Drawer {
     // otherwise create the image if we don't already have one, update
     // the href to whatever we want it to be, and hide it if we don't
     // have one
-    img = this.getOrCreateImage_(prefix, row, col);
+    img = this.getOrCreateImage_(prefix, row, col, true, squareSize);
     if (img) {
       img.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', href || '');
       img.setAttribute('visibility', href ? 'visible' : 'hidden');
@@ -93,7 +93,7 @@ module.exports = class Drawer {
    * @param {boolean} createClipPath
    * @return {Element} img
    */
-  getOrCreateImage_(prefix, row, col, createClipPath=true, squareSize=SQUARE_SIZE) {
+  getOrCreateImage_(prefix, row, col, createClipPath = true, squareSize = SQUARE_SIZE) {
     let href = this.getAsset(prefix, row, col);
 
     let imgId = Drawer.cellId(prefix, row, col);
@@ -148,17 +148,28 @@ module.exports = class Drawer {
    * @param {number} row
    * @param {number} col
    * @param {string} text
+   * @param {number} squareSize (optional): size of tile
+   * @param {number} hPadding (optional): horizontal padding from bottom left corner
+   * @param {number} vPadding (optional): vertical padding from bottom left corner
+   * @param {string} className (optional): css class name to apply to the text element
    */
-  updateOrCreateText_(prefix, row, col, text, squareSize = SQUARE_SIZE) {
+  updateOrCreateText_(
+    prefix,
+    row,
+    col,
+    text, 
+    squareSize = SQUARE_SIZE, 
+    hPadding = 2,
+    vPadding = 2,
+    className = 'karel-counter-text'
+  ) {
     const pegmanElement = this.svg_.getElementsByClassName('pegman-location')[0];
     let textElement = this.svg_.querySelector('#' + Drawer.cellId(prefix, row, col));
 
     if (!textElement) {
       // Create text.
-      const hPadding = 2;
-      const vPadding = 2;
       textElement = document.createElementNS(SVG_NS, 'text');
-      textElement.setAttribute('class', 'karel-counter-text');
+      textElement.setAttribute('class', className);
 
       // Position text just inside the bottom right corner.
       textElement.setAttribute('x', (col + 1) * squareSize - hPadding);

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -93,7 +93,7 @@ module.exports = class Drawer {
    * @param {boolean} createClipPath
    * @return {Element} img
    */
-  getOrCreateImage_(prefix, row, col, createClipPath=true) {
+  getOrCreateImage_(prefix, row, col, createClipPath=true, squareSize=SQUARE_SIZE) {
     let href = this.getAsset(prefix, row, col);
 
     let imgId = Drawer.cellId(prefix, row, col);
@@ -118,10 +118,10 @@ module.exports = class Drawer {
       let clip = document.createElementNS(SVG_NS, 'clipPath');
       clip.setAttribute('id', clipId);
       let rect = document.createElementNS(SVG_NS, 'rect');
-      rect.setAttribute('x', col * SQUARE_SIZE);
-      rect.setAttribute('y', row * SQUARE_SIZE);
-      rect.setAttribute('width', SQUARE_SIZE);
-      rect.setAttribute('height', SQUARE_SIZE);
+      rect.setAttribute('x', col * squareSize);
+      rect.setAttribute('y', row * squareSize);
+      rect.setAttribute('width', squareSize);
+      rect.setAttribute('height', squareSize);
       clip.appendChild(rect);
       this.svg_.insertBefore(clip, pegmanElement);
     }
@@ -129,10 +129,10 @@ module.exports = class Drawer {
     // Create image.
     img = document.createElementNS(SVG_NS, 'image');
     img.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', href);
-    img.setAttribute('height', SQUARE_SIZE);
-    img.setAttribute('width', SQUARE_SIZE);
-    img.setAttribute('x', SQUARE_SIZE * col);
-    img.setAttribute('y', SQUARE_SIZE * row);
+    img.setAttribute('height', squareSize);
+    img.setAttribute('width', squareSize);
+    img.setAttribute('x', squareSize * col);
+    img.setAttribute('y', squareSize * row);
     img.setAttribute('id', imgId);
     if (createClipPath) {
       img.setAttribute('clip-path', 'url(#' + clipId + ')');
@@ -149,7 +149,7 @@ module.exports = class Drawer {
    * @param {number} col
    * @param {string} text
    */
-  updateOrCreateText_(prefix, row, col, text) {
+  updateOrCreateText_(prefix, row, col, text, squareSize = SQUARE_SIZE) {
     const pegmanElement = this.svg_.getElementsByClassName('pegman-location')[0];
     let textElement = this.svg_.querySelector('#' + Drawer.cellId(prefix, row, col));
 
@@ -161,8 +161,8 @@ module.exports = class Drawer {
       textElement.setAttribute('class', 'karel-counter-text');
 
       // Position text just inside the bottom right corner.
-      textElement.setAttribute('x', (col + 1) * SQUARE_SIZE - hPadding);
-      textElement.setAttribute('y', (row + 1) * SQUARE_SIZE - vPadding);
+      textElement.setAttribute('x', (col + 1) * squareSize - hPadding);
+      textElement.setAttribute('y', (row + 1) * squareSize - vPadding);
       textElement.setAttribute('id', Drawer.cellId(prefix, row, col));
       textElement.appendChild(document.createTextNode(''));
       this.svg_.insertBefore(textElement, pegmanElement);

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -51,7 +51,7 @@ module.exports = class Drawer {
    * @param {number} col
    * @param {boolean} running
    */
-  updateItemImage(row, col, running, squareSize = SQUARE_SIZE) {
+  updateItemImage(row, col, running, squareSize=SQUARE_SIZE) {
     return this.drawImage_('', row, col, squareSize);
   }
 
@@ -62,7 +62,7 @@ module.exports = class Drawer {
    * @param {number} col
    * @return {Element} img
    */
-  drawImage_(prefix, row, col, squareSize = SQUARE_SIZE) {
+  drawImage_(prefix, row, col, squareSize=SQUARE_SIZE) {
     let img = this.svg_.querySelector('#' + Drawer.cellId(prefix, row, col));
     let href = this.getAsset(prefix, row, col);
 
@@ -93,7 +93,7 @@ module.exports = class Drawer {
    * @param {boolean} createClipPath
    * @return {Element} img
    */
-  getOrCreateImage_(prefix, row, col, createClipPath = true, squareSize = SQUARE_SIZE) {
+  getOrCreateImage_(prefix, row, col, createClipPath=true, squareSize=SQUARE_SIZE) {
     let href = this.getAsset(prefix, row, col);
 
     let imgId = Drawer.cellId(prefix, row, col);
@@ -158,10 +158,10 @@ module.exports = class Drawer {
     row,
     col,
     text, 
-    squareSize = SQUARE_SIZE, 
-    hPadding = 2,
-    vPadding = 2,
-    className = 'karel-counter-text'
+    squareSize=SQUARE_SIZE, 
+    hPadding=2,
+    vPadding=2,
+    className='karel-counter-text'
   ) {
     const pegmanElement = this.svg_.getElementsByClassName('pegman-location')[0];
     let textElement = this.svg_.querySelector('#' + Drawer.cellId(prefix, row, col));

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -41,7 +41,7 @@ module.exports = class Neighborhood extends Subtype {
     // Compute and draw the tile for each square.
     let tileId = 0;
     this.maze_.map.forEachCell((cell, row, col) => {
-      const asset = this.drawer.getAsset('', row, col);
+      const asset = this.drawer.getBackgroundTileInfo(row, col);
 
       // draw blank tile
       this.drawTile(svg, [0, 0], row, col, tileId);
@@ -62,6 +62,7 @@ module.exports = class Neighborhood extends Subtype {
           this.squareSize
         );
       }
+      this.drawer.updateItemImage(row, col, false);
       tileId++;
     });
   }
@@ -100,6 +101,15 @@ module.exports = class Neighborhood extends Subtype {
     const cell = this.getCell(row, col);
     cell.setColor(null);
     this.drawer.resetTile(row, col);
+    this.drawer.updateItemImage(row, col, true);
+  }
+
+  takePaint(pegmanId) {
+    const col = this.maze_.getPegmanX(pegmanId);
+    const row = this.maze_.getPegmanY(pegmanId);
+
+    const cell = this.getCell(row, col);
+    cell.setCurrentValue(cell.getCurrentValue() - 1);
     this.drawer.updateItemImage(row, col, true);
   }
 

--- a/src/neighborhoodCell.js
+++ b/src/neighborhoodCell.js
@@ -2,15 +2,10 @@ const Cell = require('./cell');
 
 module.exports = class NeighborhoodCell extends Cell {
   // value is paint count
-  constructor(tileType, value, assetId, hasBucket, color) {
+  constructor(tileType, value, assetId, color) {
     super(tileType, value);
     this.assetId = assetId;
-    this.hasBucket = hasBucket || value > 0;
     this.color = color;
-  }
-
-  hasBucket() {
-    return this.hasBucket;
   }
 
   getColor() {
@@ -34,7 +29,6 @@ module.exports = class NeighborhoodCell extends Cell {
     return {
       ...super.serialize(),
       assetId: this.assetId,
-      hasBucket: this.hasBucket,
       color: this.color
     };
   }
@@ -47,7 +41,6 @@ module.exports = class NeighborhoodCell extends Cell {
       serialized.tileType,
       serialized.value,
       serialized.assetId,
-      serialized.hasBucket,
       serialized.color
     );
   }

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -208,8 +208,8 @@ module.exports = class NeighborhoodDrawer extends Drawer {
       const newValue = cell.getCurrentValue() > 0 ? cell.getCurrentValue() : '';
       // drawImage_ calls getAsset. If currentValue() is 0, getAsset will return
       // undefined and the paint can will be hidden. Otherwise we will get the paint can image.
-      super.drawImage_('', r, co);
-      this.updateOrCreateText_('counter', r, co, newValue, this.squareSize);
+      super.drawImage_('', r, co, this.squareSize);
+      super.updateOrCreateText_('counter', r, co, newValue, this.squareSize, 1, 1, 'karel-counter-text paint');
     }
 
     // Because this processes a grid of cells at a time, we start at -1 to allow for
@@ -250,35 +250,4 @@ module.exports = class NeighborhoodDrawer extends Drawer {
       }
     }
   }
-
-  /**
-   * @override
-   * Create SVG text element for given cell
-   * @param {string} prefix
-   * @param {number} row
-   * @param {number} col
-   * @param {string} text
-  */
-  // updateOrCreateText_(prefix, row, col, text) {
-  //   const pegmanElement = this.svg_.getElementsByClassName('pegman-location')[0];
-  //   let textElement = this.svg_.querySelector('#' + Drawer.cellId(prefix, row, col));
-
-  //   if (!textElement) {
-  //     // Create text.
-  //     //const hPadding = this.squareSize / 4;
-  //     //const vPadding = this.squareSize / 4;
-  //     textElement = document.createElementNS(SVG_NS, 'text');
-  //     textElement.setAttribute('class', 'paint-counter-text');
-
-  //     // Position text in center of asset.
-  //     textElement.setAttribute('x', (col) * this.squareSize + this.squareSize / 2);
-  //     textElement.setAttribute('y', (row) * this.squareSize + this.squareSize / 2 + 5);
-  //     textElement.setAttribute('id', Drawer.cellId(prefix, row, col));
-  //     textElement.appendChild(document.createTextNode(''));
-  //     this.svg_.insertBefore(textElement, pegmanElement);
-  //   }
-
-  //   textElement.firstChild.nodeValue = text;
-  //   return textElement;
-  // }
 };

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -1,4 +1,4 @@
-const { SQUARE_SIZE, SVG_NS } = require("./drawer");
+const { SVG_NS } = require("./drawer");
 const Drawer = require('./drawer')
 const tiles = require('./tiles');
 
@@ -44,14 +44,6 @@ function cutout(size) {
   let halfSize = size / 2;
   let quarterSize = size / 4;
   return `m0 0v${halfSize}c0-${quarterSize} ${quarterSize}-${halfSize} ${halfSize}-${halfSize}z`
-}
-
-function makeGrid(row, col, svg) {
-  let id = "g" + row + "." + col;
-  return svgElement("g", {
-    transform: `translate(${col * SQUARE_SIZE + SQUARE_SIZE}, 
-      ${row * SQUARE_SIZE + SQUARE_SIZE})`
-  }, svg, id);
 }
 
 module.exports = class NeighborhoodDrawer extends Drawer {
@@ -116,8 +108,8 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
   // Helper method for determining color and path based on neighbors
   pathCalculator(subjectCell, adjacent1, adjacent2, diagonal, transform, grid, id) {
-    let pie = quarterCircle(SQUARE_SIZE);
-    let cutOut = cutout(SQUARE_SIZE);
+    let pie = quarterCircle(this.squareSize);
+    let cutOut = cutout(this.squareSize);
     let tag = "path";
 
     // Add a quarter circle to the top left corner of the block if there is 
@@ -144,6 +136,14 @@ module.exports = class NeighborhoodDrawer extends Drawer {
       (diagonal === subjectCell && ((!adjacent1 || !adjacent2) || adjacent1 !== adjacent2)))) {
       svgElement(tag, {d: cutOut, stroke: subjectCell, transform: transform, fill: subjectCell}, grid, `${id}-${CUT}`);
     }
+  }
+
+  makeGrid(row, col, svg) {
+    let id = "g" + row + "." + col;
+    return svgElement("g", {
+      transform: `translate(${col * this.squareSize + this.squareSize}, 
+        ${row * this.squareSize + this.squareSize})`
+    }, svg, id);
   }
 
   /**
@@ -182,10 +182,10 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     // and with the correct value.
     if (cell.getOriginalValue() > 0) {
       const newValue = cell.getCurrentValue() > 0 ? cell.getCurrentValue() : '';
-      super.updateOrCreateText_('counter', r, co, newValue);
       // drawImage_ calls getAsset. If currentValue() is 0, getAsset will return
       // undefined and the paint can will be hidden. Otherwise we will get the paint can image.
       super.drawImage_('', r, co);
+      this.updateOrCreateText_('counter', r, co, newValue, this.squareSize);
     }
 
     // Because this processes a grid of cells at a time, we start at -1 to allow for
@@ -211,7 +211,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
         if (cells[0] || cells[1] || cells[2] || cells[3]) {
           // Create grid block group
-          let grid = makeGrid(row, col, this.svg_);
+          let grid = this.makeGrid(row, col, this.svg_);
           let id0 = row + "." + col + "." + ROTATE180;
           let id1 = row + "." + col + "." + ROTATENEG90;
           let id2 = row + "." + col + "." + ROTATE90;
@@ -226,4 +226,35 @@ module.exports = class NeighborhoodDrawer extends Drawer {
       }
     }
   }
+
+  /**
+   * @override
+   * Create SVG text element for given cell
+   * @param {string} prefix
+   * @param {number} row
+   * @param {number} col
+   * @param {string} text
+  */
+  // updateOrCreateText_(prefix, row, col, text) {
+  //   const pegmanElement = this.svg_.getElementsByClassName('pegman-location')[0];
+  //   let textElement = this.svg_.querySelector('#' + Drawer.cellId(prefix, row, col));
+
+  //   if (!textElement) {
+  //     // Create text.
+  //     //const hPadding = this.squareSize / 4;
+  //     //const vPadding = this.squareSize / 4;
+  //     textElement = document.createElementNS(SVG_NS, 'text');
+  //     textElement.setAttribute('class', 'paint-counter-text');
+
+  //     // Position text in center of asset.
+  //     textElement.setAttribute('x', (col) * this.squareSize + this.squareSize / 2);
+  //     textElement.setAttribute('y', (row) * this.squareSize + this.squareSize / 2 + 5);
+  //     textElement.setAttribute('id', Drawer.cellId(prefix, row, col));
+  //     textElement.appendChild(document.createTextNode(''));
+  //     this.svg_.insertBefore(textElement, pegmanElement);
+  //   }
+
+  //   textElement.firstChild.nodeValue = text;
+  //   return textElement;
+  // }
 };

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -195,11 +195,15 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
   /**
    * @override
-   * This method is used to display the paint, so has to reprocess the entire grid
-   * to get the paint glomming correct
+   * This method is used to display the paint and paint buckets.
+   * It has to reprocess the entire grid to get the paint glomming correct, but
+   * it only updates the bucket at the specified itemRow and itemCol if necessary. 
+   * @param {number} itemRow: row of update
+   * @param {number} itemCol: column of update
+   * @param {boolean} running: if the maze is currently running (not used here, but part of signature of super)
    */
-  updateItemImage(r, co, running) {
-    let cell = this.map_.getCell(r, co);
+  updateItemImage(itemRow, itemCol, running) {
+    let cell = this.map_.getCell(itemRow, itemCol);
 
     // if the cell value has ever been greater than 0, this has been or 
     // is a paint can square. Ensure it is shown/hidden appropriately 
@@ -208,8 +212,8 @@ module.exports = class NeighborhoodDrawer extends Drawer {
       const newValue = cell.getCurrentValue() > 0 ? cell.getCurrentValue() : '';
       // drawImage_ calls getAsset. If currentValue() is 0, getAsset will return
       // undefined and the paint can will be hidden. Otherwise we will get the paint can image.
-      super.drawImage_('', r, co, this.squareSize);
-      super.updateOrCreateText_('counter', r, co, newValue, this.squareSize, 1, 1, 'karel-counter-text paint');
+      super.drawImage_('', itemRow, itemCol, this.squareSize);
+      super.updateOrCreateText_('counter', itemRow, itemCol, newValue, this.squareSize, 1, 1, 'karel-counter-text paint');
     }
 
     // Because this processes a grid of cells at a time, we start at -1 to allow for


### PR DESCRIPTION
Add paint bucket rendering to neighborhood. Paint buckets are handled very similarly to crops in farmer or gems in collector. We treat the paint bucket as an image and a value text that we display in the bottom-left corner of the cell. If the value goes to 0, the paint bucket disappears. This PR also adds support for the take paint command, which decreases the value in the bucket by 1.

This PR also includes some refactoring in drawer to include an optional squareSize variable (that defaults to the existing constant in that file), which we use to enable our different square size that neighborhood uses. I also updated neighborhoodDrawer to use our dynamic squareSize field instead of the constant of 50.

Sample screenshots (paint buckets will have at most 99 units of paint)
8x8 grid
![Screen Shot 2021-05-28 at 11 45 33 AM](https://user-images.githubusercontent.com/33666587/120029260-b1025e00-bfaa-11eb-8406-630feeb3d8b1.png)


15x15 grid (max size we allow paint buckets)
![Screen Shot 2021-05-28 at 11 44 45 AM](https://user-images.githubusercontent.com/33666587/120029237-a942b980-bfaa-11eb-8d67-a2face9e03fc.png)

The actual styling of the number is done on the code-dot-org side, so I added an additional css class to the paint value so we can have a different font size than our standard version (since our squares are smaller than the usual maze squares).