### PR TITLE
Add left-turn command maze side

### DIFF
--- a/src/animationsController.js
+++ b/src/animationsController.js
@@ -393,7 +393,8 @@ module.exports = class AnimationsController {
   }
 
   /**
-   * Schedule the animations for a turn to the given direction.
+   * Schedule the animations for a turn to the given direction, without
+   * animating any of the intermediate frames.
    * @param {number} endDirection The direction we're turning to  
    * @param {string} pegmanId Optional id of pegman. If no id is provided,
    *   will schedule turn for default pegman.

--- a/src/animationsController.js
+++ b/src/animationsController.js
@@ -392,6 +392,25 @@ module.exports = class AnimationsController {
     });
   }
 
+  /**
+   * Schedule the animations for a turn from the current direction
+   * @param {number} endDirection The direction we're turning to  
+   * @param {string} pegmanId Optional id of pegman. If no id is provided,
+   *   will schedule turn for default pegman.
+   */
+  simpleTurn(endDirection, pegmanId) {
+    var numFrames = 2;
+    utils.range(1, numFrames).forEach((frame) => {
+      timeoutList.setTimeout(() => {
+        this.displayPegman(
+          this.maze.getPegmanX(pegmanId),
+          this.maze.getPegmanY(pegmanId),
+          tiles.directionToFrame(endDirection),
+          pegmanId);
+        }, this.maze.stepSpeed * (frame - 1));
+    });    
+  }
+
   crackSurroundingIce(targetX, targetY) {
     // Remove cracked ice, replace surrounding ice with cracked ice.
     this.updateSurroundingTiles_(targetY, targetX, (tileElement, cell) => {

--- a/src/animationsController.js
+++ b/src/animationsController.js
@@ -393,7 +393,7 @@ module.exports = class AnimationsController {
   }
 
   /**
-   * Schedule the animations for a turn from the current direction
+   * Schedule the animations for a turn to the given direction.
    * @param {number} endDirection The direction we're turning to  
    * @param {string} pegmanId Optional id of pegman. If no id is provided,
    *   will schedule turn for default pegman.

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -277,7 +277,7 @@ module.exports = class MazeController {
   }
 
   animatedCardinalTurn(direction, id) {
-    this.animationsController.scheduleTurn(direction, id);
+    this.animationsController.simpleTurn(direction, id);
     this.setPegmanD(direction, id);
   }
 

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -276,6 +276,11 @@ module.exports = class MazeController {
     this.setPegmanD(tiles.constrainDirection4(newDirection), id);
   }
 
+  animatedCardinalTurn(direction, id) {
+    this.animationsController.scheduleTurn(direction, id);
+    this.setPegmanD(direction, id);
+  }
+
   animatedFail(forward, id) {
     var dxDy = tiles.directionToDxDy(this.getPegmanD(id));
     var deltaX = dxDy.dx;

--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -276,6 +276,12 @@ module.exports = class MazeController {
     this.setPegmanD(tiles.constrainDirection4(newDirection), id);
   }
 
+  /**
+   * A version of animated turn that bypasses the mod in animatedTurn
+   * and moves straight to the direction given.
+   * @param direction 
+   * @param id 
+   */
   animatedCardinalTurn(direction, id) {
     this.animationsController.simpleTurn(direction, id);
     this.setPegmanD(direction, id);

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -1,6 +1,7 @@
 import Subtype from './subtype';
 import NeighborhoodCell from './neighborhoodCell';
 import NeighborhoodDrawer from './neighborhoodDrawer';
+import { Direction } from './tiles';
 
 module.exports = class Neighborhood extends Subtype {
   constructor(maze, config = {}) {
@@ -100,6 +101,29 @@ module.exports = class Neighborhood extends Subtype {
     cell.setColor(null);
     this.drawer.resetTile(row, col);
     this.drawer.updateItemImage(row, col, true);
+  }
+
+  /**
+   * Turns the painter left by one direction.
+   * @param {String} pegmanId
+   */
+  turnLeft(pegmanId) {
+    const newDirection;
+    switch (this.maze_.getPegmanD(pegmanId)) {
+      case Direction.NORTH:
+        newDirection = Direction.WEST;
+        break;
+      case Direction.EAST:
+        newDirection = Direction.NORTH;
+        break;
+      case Direction.SOUTH:
+        newDirection = Direction.EAST;
+        break;
+      case Direction.WEST:
+        newDirection = Direction.SOUTH;
+        break;
+    }
+    this.maze_.animatedTurn(newDirection, pegmanId);
   }
 
   // Sprite map maps asset ids to sprites within a spritesheet.

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -108,7 +108,7 @@ module.exports = class Neighborhood extends Subtype {
    * @param {String} pegmanId
    */
   turnLeft(pegmanId) {
-    const newDirection = null;
+    let newDirection = null;
     switch (this.maze_.getPegmanD(pegmanId)) {
       case Direction.NORTH:
         newDirection = Direction.WEST;

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -108,7 +108,7 @@ module.exports = class Neighborhood extends Subtype {
    * @param {String} pegmanId
    */
   turnLeft(pegmanId) {
-    const newDirection;
+    const newDirection = null;
     switch (this.maze_.getPegmanD(pegmanId)) {
       case Direction.NORTH:
         newDirection = Direction.WEST;

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -124,9 +124,9 @@ module.exports = class Neighborhood extends Subtype {
         newDirection = Direction.SOUTH;
         break;
     }
-    this.maze_.animatedTurn(newDirection, pegmanId);
+    this.maze_.animatedCardinalTurn(newDirection, pegmanId);
   }
-  
+
   takePaint(pegmanId) {
     const col = this.maze_.getPegmanX(pegmanId);
     const row = this.maze_.getPegmanY(pegmanId);


### PR DESCRIPTION
This is the corresponding PR to https://github.com/code-dot-org/code-dot-org/pull/40861 for the turnLeft() command. 

It required making a custom scheduleTurn() and a custom animatedTurn(), because the existing methods don't work with cardinal directions, and assume the avatar spritesheet has additional frames for turning the pegman.


https://user-images.githubusercontent.com/37230822/120400255-5e9aa780-c2f2-11eb-9647-a463b57fd5f4.mp4



Jira Ticket: https://codedotorg.atlassian.net/browse/CSA-357