### PR TITLE
Neighborhood: Fix background tiles

### DIFF
--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -40,10 +40,10 @@ module.exports = class Neighborhood extends Subtype {
     // Compute and draw the tile for each square.
     let tileId = 0;
     this.maze_.map.forEachCell((cell, row, col) => {
-      const asset = this.drawer.getBackgroundTileInfo(row, col);
-
       // draw blank tile
       this.drawTile(svg, [0, 0], row, col, tileId);
+
+      const asset = this.drawer.getBackgroundTileInfo(row, col);
       if (asset) {
         // add assset on top of blank tile if it exists
         // asset is in format {name: 'sample name', sheet: x, row: y, column: z}
@@ -54,7 +54,7 @@ module.exports = class Neighborhood extends Subtype {
           [asset.column, asset.row], 
           row, 
           col, 
-          tileId, 
+          `${tileId}-asset`, 
           assetHref,
           sheetWidth, 
           sheetHeight, 

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -109,7 +109,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     const cell = this.neighborhood.getCell(row, col);
     // If the tile has an asset id and it is > 0 (0 is a blank tile and will always be added),
     // return the sprite asset. 
-    // Ignore the asset id if this is a start tile or the cell has a value value. 
+    // Ignore the asset id if this is a start tile or the cell has an original value. 
     // Start tiles will handle placing the pegman separately,
     // and tiles with a value are paint cans, which are handled as images instead of background tiles.
     if (cell.getAssetId() != null && cell.getAssetId() > 0 &&

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -107,11 +107,13 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
   getBackgroundTileInfo(row, col) {
     const cell = this.neighborhood.getCell(row, col);
-    // If the tile has an asset id, return the sprite asset. Ignore the asset id
-    // if this is a start tile or the cell has a value value. 
+    // If the tile has an asset id and it is > 0 (0 is a blank tile and will always be added),
+    // return the sprite asset. 
+    // Ignore the asset id if this is a start tile or the cell has a value value. 
     // Start tiles will handle placing the pegman separately,
     // and tiles with a value are paint cans, which are handled as images instead of background tiles.
-    if (cell.getAssetId() != null && cell.getTile() !== tiles.SquareType.START && !cell.getOriginalValue()) {
+    if (cell.getAssetId() != null && cell.getAssetId() > 0 &&
+        cell.getTile() !== tiles.SquareType.START && !cell.getOriginalValue()) {
       return this.getSpriteData(cell);
     }
   }


### PR DESCRIPTION
We were rendering the blacktop tiles on neighborhood in two different ways--we always put down the png from 'tiles.png', and then if the tile had an asset id of 0 we were layering on top the blacktop png from the 'other' spritesheet. This caused slightly variation in color on certain browsers, and we could see lines from the spritesheet version at certain resolutions. This PR updates the neighborhood subtype to ignore asset id 0 from its rendering of tiles, as we are already handling placing the blacktop tile separately. Also updated the additional asset on a tile to have a different id from the blacktop tile.

Before fix:
![Screen Shot 2021-06-01 at 11 45 49 AM](https://user-images.githubusercontent.com/33666587/120375522-bffd4f00-c2cf-11eb-8cd6-7cf899cdda4f.png)

After fix:
![Screen Shot 2021-06-01 at 11 50 44 AM](https://user-images.githubusercontent.com/33666587/120375540-c7245d00-c2cf-11eb-848b-7bea7cb433f0.png)

