### PR TITLE
Implement reset to remove paint from all tiles on rerun

### DIFF
--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -90,16 +90,13 @@ module.exports = class Neighborhood extends Subtype {
   }
 
   /**
-   * Remove paint from the location of the pegman with id pegmanId, if there
-   * is any paint.
+   * Remove paint from the location of the pegman with id pegmanId.
    * @param {String} pegmanId
   **/ 
  removePaint(pegmanId) {
     const col = this.maze_.getPegmanX(pegmanId);
     const row = this.maze_.getPegmanY(pegmanId);
 
-    const cell = this.getCell(row, col);
-    cell.setColor(null);
     this.drawer.resetTile(row, col);
     this.drawer.updateItemImage(row, col, true);
   }

--- a/src/neighborhood.js
+++ b/src/neighborhood.js
@@ -136,6 +136,10 @@ module.exports = class Neighborhood extends Subtype {
     this.drawer.updateItemImage(row, col, true);
   }
 
+  reset() {
+    this.drawer.resetTiles();
+  }
+
   // Sprite map maps asset ids to sprites within a spritesheet.
   getSpriteMap() {
     return this.spriteMap;

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -79,6 +79,13 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     this.skin_ = skin;
   }
 
+  /**
+   * Set the color of this tile back to null, and remove any svg elements
+   * (colors) that currently exist on this tile and its neighbors. 
+   * 
+   * @param row 
+   * @param col 
+   */
   resetTile(row, col) {
     let neighbors = [
       "g" + row + "." + col,
@@ -86,6 +93,8 @@ module.exports = class NeighborhoodDrawer extends Drawer {
       "g" + row + "." + (col - 1),
       "g" + (row - 1) + "." + col
     ];
+    const cell = this.neighborhood.getCell(row, col);
+    cell.setColor(null);
     for (const neighbor of neighbors) {
       var node = document.getElementById(neighbor);
       if (node) {
@@ -123,13 +132,11 @@ module.exports = class NeighborhoodDrawer extends Drawer {
   }
 
   /**
-   * Clears the paint from each tile.
+   * Calls resetTile for each tile in the grid, clearing all paint.
    */
   resetTiles() {
     for (let row = 0; row < this.map_.ROWS; row++) {
       for (let col = 0; col < this.map_.COLS; col++) {
-        const cell = this.neighborhood.getCell(row, col);
-        cell.setColor(null);
         this.resetTile(row, col);
       }
     }

--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -122,7 +122,18 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     return this.neighborhood.getSpriteMap()[cell.getAssetId()];
   }
 
-  resetTiles() {}
+  /**
+   * Clears the paint from each tile.
+   */
+  resetTiles() {
+    for (let row = 0; row < this.map_.ROWS; row++) {
+      for (let col = 0; col < this.map_.COLS; col++) {
+        const cell = this.neighborhood.getCell(row, col);
+        cell.setColor(null);
+        this.resetTile(row, col);
+      }
+    }
+  }
 
   // Quick helper to retrieve the color stored in this cell
   // Ensures 'padding cells' (row/col < 0) have no color


### PR DESCRIPTION
This PR sets up resetTiles(), which loops through the grid calling the existing resetTile(). This method sets cellColor to null and clears out any existing color svg elements. Also includes a refactor of resetTile to pull the setColor(null) away from removePaint() and into this function to avoid repeated code.

There are also a few additional updates/clarifications to comments in NeighborhoodDrawer.

A potential future optimization: instead of looping through the entire grid, track what colors have been painted and only reset those tiles. Alternatively: loop through every third tile and set all neighbors to null, as the neighbor svg paths are already cleared using resetTile(). 

![resetgif](https://user-images.githubusercontent.com/37230822/120414901-8cdab000-c30f-11eb-83b7-576e250c2d2e.gif)


Jira: https://codedotorg.atlassian.net/browse/CSA-410