### PR TITLE
Editing paint glomming algorithm, changing L case, circle case, and center case

### DIFF
--- a/src/neighborhoodSquareDrawer.js
+++ b/src/neighborhoodSquareDrawer.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const { SVG_NS } = require("./drawer");
 const Drawer = require("./drawer");
 const tiles = require("./tiles");
@@ -167,8 +168,8 @@ function generateCenterPath(
  * if either. Add the corner cutout if the corner is the same color as the adjacent cells.
  * Only add the triangle half-grids if there is no color in the outside corner.
  */
-function cornerFill(grid, id, size, adjacentColor, cornerColor, corner) {
-  if (cornerColor && cornerColor === adjacentColor) {
+function cornerFill(grid, id, size, adjacentColor, cornerColor, farCorner1, farCorner2, corner) {
+  if (cornerColor && cornerColor === adjacentColor && (cornerColor === farCorner1 || cornerColor === farCorner2)) {
     smallCornerSvg(adjacentColor, grid, id, size, corner);
   } else if (!cornerColor) {
     triangleSvg(adjacentColor, grid, id, size, corner);
@@ -308,6 +309,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
    * @param id the row and column we're on in id form
    */
   colorCells(cellColorList, grid, id) {
+    console.log("coloring");
     let size = this.squareSize;
 
     let topLeft = cellColorList[0];
@@ -326,40 +328,26 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     if (node) {
       node.querySelectorAll("*").forEach((n) => n.remove());
     }
-
     // if the center cell has paint, calculate its fill and corners
     if (center) {
+      console.log("we have color in the middle");
       this.centerFill(cellColorList, grid, id);
     }
-    // the circle case: ensure the center cell only has small corners if
-    // all surrounding cells are matching (this prevents a filled-in center)
-    else if (
-      top &&
-      left &&
-      bottom &&
-      right &&
-      top === left &&
-      left === bottom &&
-      bottom === right
-    ) {
-      smallCornerSvg(top, grid, id, size, Corner.topLeft);
-      smallCornerSvg(top, grid, id, size, Corner.topRight);
-      smallCornerSvg(bottom, grid, id, size, Corner.bottomLeft);
-      smallCornerSvg(bottom, grid, id, size, Corner.bottomRight);
-    } else {
+    else {
+      console.log("made it inside the else");
       // Check each set of adjacent neighbors and the corresponding corner cell
       // to determine if small corners or triangle half-grids should be added.
       if (top && right && top === right) {
-        cornerFill(grid, id, size, top, topRight, Corner.topRight);
+        cornerFill(grid, id, size, top, topRight, topLeft, bottomRight, Corner.topRight);
       }
       if (right && bottom && right === bottom) {
-        cornerFill(grid, id, size, right, bottomRight, Corner.bottomRight);
+        cornerFill(grid, id, size, right, bottomRight, topRight, bottomLeft, Corner.bottomRight);
       }
       if (bottom && left && bottom === left) {
-        cornerFill(grid, id, size, bottom, bottomLeft, Corner.bottomLeft);
+        cornerFill(grid, id, size, bottom, bottomLeft, bottomRight, topLeft, Corner.bottomLeft);
       }
       if (left && top && left === top) {
-        cornerFill(grid, id, size, left, topLeft, Corner.topLeft);
+        cornerFill(grid, id, size, left, topLeft, bottomLeft, topRight, Corner.topLeft);
       }
     }
   }
@@ -457,6 +445,7 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
     // Only calculate colors for all neighbors if this cell has a color
     if (this.cellColor(row, col)) {
+      console.log("starting to draw things here");
       for (let r = row - 1; r < row + 2; r++) {
         for (let c = col - 1; c < col + 2; c++) {
           let id = r + "." + c;

--- a/src/neighborhoodSquareDrawer.js
+++ b/src/neighborhoodSquareDrawer.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 const { SVG_NS } = require("./drawer");
 const Drawer = require("./drawer");
 const tiles = require("./tiles");
@@ -165,8 +164,10 @@ function generateCenterPath(
 
 /**
  * Determines whether we should create a small corner SVG or a grid half triangle SVG,
- * if either. Add the corner cutout if the corner is the same color as the adjacent cells.
- * Only add the triangle half-grids if there is no color in the outside corner.
+ * if either. Add the corner cutout if the corner is the same color as the adjacent
+ * cells, and at least one of the two corners on the other sides of the adjacent cells
+ * with that same color. Add the triangle half-grids if the corner is the same color as
+ * the adjacent cells, or has no color at all.
  */
 function cornerFill(
   grid,

--- a/src/neighborhoodSquareDrawer.js
+++ b/src/neighborhoodSquareDrawer.js
@@ -171,7 +171,7 @@ function generateCenterPath(
 function cornerFill(grid, id, size, adjacentColor, cornerColor, farCorner1, farCorner2, corner) {
   if (cornerColor && cornerColor === adjacentColor && (cornerColor === farCorner1 || cornerColor === farCorner2)) {
     smallCornerSvg(adjacentColor, grid, id, size, corner);
-  } else if (!cornerColor) {
+  } else if (!cornerColor || cornerColor === adjacentColor) {
     triangleSvg(adjacentColor, grid, id, size, corner);
   }
 }
@@ -267,19 +267,23 @@ module.exports = class NeighborhoodDrawer extends Drawer {
    * of the adjacent neighbors.
    */
   centerFill(cellColorList, grid, id) {
-    let center = cellColorList[4];
+    let topLeft = cellColorList[0];
     let top = cellColorList[1];
-    let right = cellColorList[5];
-    let bottom = cellColorList[7];
+    let topRight = cellColorList[2];
     let left = cellColorList[3];
+    let center = cellColorList[4];
+    let right = cellColorList[5];
+    let bottomLeft = cellColorList[6];
+    let bottom = cellColorList[7];
+    let bottomRight = cellColorList[8];
     var path;
-    if (center == top && center == right && !bottom && !left)
+    if (center == top && center == right && !bottom && !left && !topLeft && !bottomRight)
       path = generateCenterPath(this.squareSize, false, false, false, true);
-    else if (center == right && center == bottom && !left && !top)
+    else if (center == right && center == bottom && !left && !top && !topRight && !bottomLeft)
       path = generateCenterPath(this.squareSize, true, false, false, false);
-    else if (center == bottom && center == left && !top && !right)
+    else if (center == bottom && center == left && !top && !right && !bottomRight && !topLeft)
       path = generateCenterPath(this.squareSize, false, true, false, false);
-    else if (center == left && center == top && !right && !bottom)
+    else if (center == left && center == top && !right && !bottom && !bottomLeft && !topRight)
       path = generateCenterPath(this.squareSize, false, false, true, false);
     else {
       path = generateCenterPath(this.squareSize, false, false, false, false);
@@ -309,7 +313,6 @@ module.exports = class NeighborhoodDrawer extends Drawer {
    * @param id the row and column we're on in id form
    */
   colorCells(cellColorList, grid, id) {
-    console.log("coloring");
     let size = this.squareSize;
 
     let topLeft = cellColorList[0];
@@ -330,11 +333,9 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     }
     // if the center cell has paint, calculate its fill and corners
     if (center) {
-      console.log("we have color in the middle");
       this.centerFill(cellColorList, grid, id);
     }
     else {
-      console.log("made it inside the else");
       // Check each set of adjacent neighbors and the corresponding corner cell
       // to determine if small corners or triangle half-grids should be added.
       if (top && right && top === right) {
@@ -445,7 +446,6 @@ module.exports = class NeighborhoodDrawer extends Drawer {
 
     // Only calculate colors for all neighbors if this cell has a color
     if (this.cellColor(row, col)) {
-      console.log("starting to draw things here");
       for (let r = row - 1; r < row + 2; r++) {
         for (let c = col - 1; c < col + 2; c++) {
           let id = r + "." + c;

--- a/src/neighborhoodSquareDrawer.js
+++ b/src/neighborhoodSquareDrawer.js
@@ -168,8 +168,21 @@ function generateCenterPath(
  * if either. Add the corner cutout if the corner is the same color as the adjacent cells.
  * Only add the triangle half-grids if there is no color in the outside corner.
  */
-function cornerFill(grid, id, size, adjacentColor, cornerColor, farCorner1, farCorner2, corner) {
-  if (cornerColor && cornerColor === adjacentColor && (cornerColor === farCorner1 || cornerColor === farCorner2)) {
+function cornerFill(
+  grid,
+  id,
+  size,
+  adjacentColor,
+  cornerColor,
+  farCorner1,
+  farCorner2,
+  corner
+) {
+  if (
+    cornerColor &&
+    cornerColor === adjacentColor &&
+    (cornerColor === farCorner1 || cornerColor === farCorner2)
+  ) {
     smallCornerSvg(adjacentColor, grid, id, size, corner);
   } else if (!cornerColor || cornerColor === adjacentColor) {
     triangleSvg(adjacentColor, grid, id, size, corner);
@@ -277,13 +290,41 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     let bottom = cellColorList[7];
     let bottomRight = cellColorList[8];
     var path;
-    if (center == top && center == right && !bottom && !left && !topLeft && !bottomRight)
+    if (
+      center == top &&
+      center == right &&
+      !bottom &&
+      !left &&
+      !topLeft &&
+      !bottomRight
+    )
       path = generateCenterPath(this.squareSize, false, false, false, true);
-    else if (center == right && center == bottom && !left && !top && !topRight && !bottomLeft)
+    else if (
+      center == right &&
+      center == bottom &&
+      !left &&
+      !top &&
+      !topRight &&
+      !bottomLeft
+    )
       path = generateCenterPath(this.squareSize, true, false, false, false);
-    else if (center == bottom && center == left && !top && !right && !bottomRight && !topLeft)
+    else if (
+      center == bottom &&
+      center == left &&
+      !top &&
+      !right &&
+      !bottomRight &&
+      !topLeft
+    )
       path = generateCenterPath(this.squareSize, false, true, false, false);
-    else if (center == left && center == top && !right && !bottom && !bottomLeft && !topRight)
+    else if (
+      center == left &&
+      center == top &&
+      !right &&
+      !bottom &&
+      !bottomLeft &&
+      !topRight
+    )
       path = generateCenterPath(this.squareSize, false, false, true, false);
     else {
       path = generateCenterPath(this.squareSize, false, false, false, false);
@@ -334,21 +375,56 @@ module.exports = class NeighborhoodDrawer extends Drawer {
     // if the center cell has paint, calculate its fill and corners
     if (center) {
       this.centerFill(cellColorList, grid, id);
-    }
-    else {
+    } else {
       // Check each set of adjacent neighbors and the corresponding corner cell
       // to determine if small corners or triangle half-grids should be added.
       if (top && right && top === right) {
-        cornerFill(grid, id, size, top, topRight, topLeft, bottomRight, Corner.topRight);
+        cornerFill(
+          grid,
+          id,
+          size,
+          top,
+          topRight,
+          topLeft,
+          bottomRight,
+          Corner.topRight
+        );
       }
       if (right && bottom && right === bottom) {
-        cornerFill(grid, id, size, right, bottomRight, topRight, bottomLeft, Corner.bottomRight);
+        cornerFill(
+          grid,
+          id,
+          size,
+          right,
+          bottomRight,
+          topRight,
+          bottomLeft,
+          Corner.bottomRight
+        );
       }
       if (bottom && left && bottom === left) {
-        cornerFill(grid, id, size, bottom, bottomLeft, bottomRight, topLeft, Corner.bottomLeft);
+        cornerFill(
+          grid,
+          id,
+          size,
+          bottom,
+          bottomLeft,
+          bottomRight,
+          topLeft,
+          Corner.bottomLeft
+        );
       }
       if (left && top && left === top) {
-        cornerFill(grid, id, size, left, topLeft, bottomLeft, topRight, Corner.topLeft);
+        cornerFill(
+          grid,
+          id,
+          size,
+          left,
+          topLeft,
+          bottomLeft,
+          topRight,
+          Corner.topLeft
+        );
       }
     }
   }


### PR DESCRIPTION
This PR edits the algorithm in three ways:

1. Removes the circle case entirely. That is, if a small "circle" is drawn with an empty center cell but its four adjacent cells filled in with one color, the center cell will naturally fill in. Before, this case ensured the center cell would only have four small corners. To see this update: look at the green circle next to the A in the images.
2. The "L" case is altered so a small corner will be added only when one of the legs of the L is longer than one cell long. See the small gold L-turned-triangle in the images below.
3. The center cell logic is updated so there will only be a corner cutout if the two off-side neighbors are empty AND their neighboring three outside corners are also empty. This is visible in the large green triangle in the lower right-hand corner.

Before:
![image](https://user-images.githubusercontent.com/37230822/124676246-0582de00-de73-11eb-9fd5-33416e4fa999.png)


After:
![image](https://user-images.githubusercontent.com/37230822/124676218-f308a480-de72-11eb-9cda-c8307a1bd751.png)
