### PR TITLE
Fixing resetTile to fix scrapePaint() bug

### DIFF
--- a/src/neighborhoodDrawer.js
+++ b/src/neighborhoodDrawer.js
@@ -209,19 +209,12 @@ module.exports = class NeighborhoodDrawer extends Drawer {
    * @param col
    */
   resetTile(row, col) {
-    let neighbors = [
-      "g" + row + "." + col,
-      "g" + (row - 1) + "." + (col - 1),
-      "g" + row + "." + (col - 1),
-      "g" + (row - 1) + "." + col,
-    ];
+    let subjectTile = "g" + row + "." + col;
     const cell = this.neighborhood.getCell(row, col);
     cell.setColor(null);
-    for (const neighbor of neighbors) {
-      var node = document.getElementById(neighbor);
-      if (node) {
-        node.querySelectorAll("*").forEach((n) => n.remove());
-      }
+    var node = document.getElementById(subjectTile);
+    if (node) {
+      node.querySelectorAll("*").forEach((n) => n.remove());
     }
   }
 


### PR DESCRIPTION
The resetTile() file hadn't been updated since the first paint glomming algorithm, which updated every tile with every paint() command. This fix updates the resetTile() to only clear out the subject cell, which eliminates the scrapePaint() issue that scrapes paint off of neighborhing tiles.

Jira: https://codedotorg.atlassian.net/browse/CSA-604

Before:
![image](https://user-images.githubusercontent.com/37230822/127906573-f78799e9-021c-48ba-8a53-cba75c7c3b5b.png)


After:
![image](https://user-images.githubusercontent.com/37230822/127906362-f161b826-3f55-4b8e-b2bc-a3be7eace213.png)
