### PR TITLE
Add show hide pegman functions to mazeController

### DIFF
--- a/src/mazeController.js
+++ b/src/mazeController.js
@@ -467,4 +467,12 @@ module.exports = class MazeController {
       this.animationsController.hidePegman();
     }
   }
+
+  showPegman(id) {
+    this.animationsController.showPegman(id);
+  }
+
+  hidePegman(id) {
+    this.animationsController.hidePegman(id);
+  }
 };


### PR DESCRIPTION
`animationsController` already had functions for show and hide pegman by id. This PR exposes those functions to clients via the `mazeController` so we can call them from code-dot-org. This enables showing and hiding painters in the neighborhood.

[jira](https://codedotorg.atlassian.net/browse/JAVA-281)