### PR TITLE
Fix JS error

### DIFF
--- a/src/animationsController.js
+++ b/src/animationsController.js
@@ -265,9 +265,15 @@ module.exports = class AnimationsController {
     */
   updatePegmanAnimation_(options) {
     var rect = document.getElementById(utils.getPegmanElementId(`${options.type}ClipRect`, options.pegmanId));
+    if (!rect) {
+      return;
+    }
     rect.setAttribute('x', options.col * this.maze.SQUARE_SIZE + 1 + this.maze.PEGMAN_X_OFFSET);
     rect.setAttribute('y', getPegmanYForRow(this.maze.skin, options.row, this.maze.SQUARE_SIZE));
     var img = document.getElementById(utils.getPegmanElementId(options.type, options.pegmanId));
+    if (!img) {
+      return;
+    }
     var x = this.maze.SQUARE_SIZE * options.col -
         options.direction * this.maze.PEGMAN_WIDTH + 1 + this.maze.PEGMAN_X_OFFSET;
     img.setAttribute('x', x);


### PR DESCRIPTION
The new highest JS error on https://studio.code.org according to New Relic, over the past 7 days, is `Error: Cannot read property 'setAttribute' of null` in which `rect` here is `null`.  It mainly occurred over a 24 hour period which has now ended, but has been seen up to 6 months ago.  There is no known repro, but the fix here should prevent more JS errors at least.  A similar check for `img` being `null` has also been added.